### PR TITLE
FFWEB-2012: Export custom fields from variants

### DIFF
--- a/src/Export/Data/Entity/EntityFactory.php
+++ b/src/Export/Data/Entity/EntityFactory.php
@@ -17,10 +17,14 @@ class EntityFactory
     /** @var FieldInterface[] */
     private $productFields;
 
-    public function __construct(PropertyFormatter $propertyFormatter, iterable $productFields)
+    /** @var FieldInterface[] */
+    private $variantFields;
+
+    public function __construct(PropertyFormatter $propertyFormatter, iterable $productFields, iterable $variantFields)
     {
         $this->propertyFormatter = $propertyFormatter;
         $this->productFields     = iterator_to_array($productFields);
+        $this->variantFields     = iterator_to_array($variantFields);
     }
 
     /**
@@ -34,7 +38,7 @@ class EntityFactory
         if ($product->getChildCount()) {
             $parentData = $entity->toArray();
             yield from $product->getChildren()->map(function (Product $child) use ($parentData) {
-                return new VariantEntity($child, $parentData, $this->propertyFormatter);
+                return new VariantEntity($child, $parentData, $this->propertyFormatter, $this->variantFields);
             });
         }
         yield $entity;

--- a/src/Export/Data/Entity/VariantEntity.php
+++ b/src/Export/Data/Entity/VariantEntity.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\Export\Data\Entity;
 
 use Omikron\FactFinder\Shopware6\Export\Data\ExportEntityInterface;
+use Omikron\FactFinder\Shopware6\Export\Field\FieldInterface;
 use Omikron\FactFinder\Shopware6\Export\PropertyFormatter;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
 use function array_map as map;
@@ -20,11 +21,19 @@ class VariantEntity implements ExportEntityInterface
     /** @var PropertyFormatter */
     private $propertyFormatter;
 
-    public function __construct(Product $product, array $parentData, PropertyFormatter $propertyFormatter)
-    {
+    /** @var FieldInterface[] */
+    private $variantFields;
+
+    public function __construct(
+        Product $product,
+        array $parentData,
+        PropertyFormatter $propertyFormatter,
+        iterable $variantFields
+    ) {
         $this->product           = $product;
         $this->parentData        = $parentData;
         $this->propertyFormatter = $propertyFormatter;
+        $this->variantFields     = $variantFields;
     }
 
     public function getId(): string
@@ -35,6 +44,8 @@ class VariantEntity implements ExportEntityInterface
     public function toArray(): array
     {
         $opts = '|' . implode('|', map($this->propertyFormatter, $this->product->getOptions()->getElements())) . '|';
-        return ['ProductNumber' => $this->product->getProductNumber(), 'FilterAttributes' => $opts] + $this->parentData;
+        return array_reduce($this->variantFields, function (array $fields, FieldInterface $field) {
+            return [$field->getName() => $field->getValue($this->product)] + $fields;
+        }, ['ProductNumber' => $this->product->getProductNumber(), 'FilterAttributes' => $opts] + $this->parentData);
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -31,6 +31,7 @@
             <bind key="$channelRepository" type="service" id="sales_channel.repository" />
             <bind key="$customFieldRepository" type="service" id="custom_field.repository" />
             <bind key="$languageRepository" type="service" id="language.repository"/>
+            <bind key="$variantFields" type="tagged_iterator" tag="factfinder.export.variant_field" />
         </defaults>
 
         <service id="Omikron\FactFinder\Communication\Resource\AdapterFactory" />
@@ -56,5 +57,9 @@
 
         <service id="Omikron\FactFinder\Shopware6\Export\Filter\FilterInterface"
                  class="Omikron\FactFinder\Shopware6\Export\Filter\TextFilter" />
+
+        <service id="Omikron\FactFinder\Shopware6\Export\Field\CustomFields">
+            <tag name="factfinder.export.variant_field" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
Description:
Added a mechanism allowing user to tag specific `FieldInterface` implementations with a `factfinder.export.variant_field`. A service tagged in this way will be added to a pool of fields which should be exported on a variant level, which means the export will prefer the variant values instead of main articles
Tested with Shopware editions/versions:
6.3.5.1
Tested with PHP versions:
7.4