### PR TITLE
FFWEB-2092: Fix naming export files during FTP upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
-
 ## [Unreleased]
 ### Add
 - Add form for run Feed export from the admin panel instead of command line
+
+### Fix
+  - Fix FTP upload does not take the channel name from correct sales channel context
 
 ## [v1.0.0] - 2021.06.29
 Initial module release. Includes Web Components v4.0.3

--- a/src/Communication/PushImportService.php
+++ b/src/Communication/PushImportService.php
@@ -8,6 +8,7 @@ use Omikron\FactFinder\Communication\Resource\Import;
 use Omikron\FactFinder\Shopware6\Config\Communication;
 use Omikron\FactFinder\Shopware6\Config\FtpConfig;
 use Omikron\FactFinder\Shopware6\Exception\ImportRunningException;
+use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
 use Psr\Http\Client\ClientExceptionInterface;
 
 class PushImportService
@@ -21,11 +22,19 @@ class PushImportService
     /** @var Import */
     private $importAdapter;
 
-    public function __construct(Import $importAdapter, Communication $communicationConfig, FtpConfig $uploadConfig)
-    {
+    /** @var SalesChannelService */
+    private $salesChannelService;
+
+    public function __construct(
+        Import $importAdapter,
+        Communication $communicationConfig,
+        FtpConfig $uploadConfig,
+        SalesChannelService $salesChannelService
+    ) {
         $this->communicationConfig = $communicationConfig;
         $this->uploadConfig        = $uploadConfig;
         $this->importAdapter       = $importAdapter;
+        $this->salesChannelService = $salesChannelService;
     }
 
     /**
@@ -33,7 +42,8 @@ class PushImportService
      */
     public function execute(): void
     {
-        $channel = $this->communicationConfig->getChannel();
+        $salesChannelId = $this->salesChannelService->getSalesChannelContext()->getSalesChannel()->getId();
+        $channel        = $this->communicationConfig->getChannel($salesChannelId);
         $this->checkNotRunning($channel);
         foreach ($this->uploadConfig->getPushImportTypes() as $type) {
             $this->importAdapter->import($channel, $type);

--- a/src/Config/BaseConfig.php
+++ b/src/Config/BaseConfig.php
@@ -17,12 +17,13 @@ abstract class BaseConfig
     }
 
     /**
-     * @param string $param
+     * @param string      $param
+     * @param string|null $salesChannelId
      *
      * @return mixed
      */
-    protected function config(string $param)
+    protected function config(string $param, ?string $salesChannelId = null)
     {
-        return $this->systemConfig->get('OmikronFactFinder.config.' . $param);
+        return $this->systemConfig->get('OmikronFactFinder.config.' . $param, $salesChannelId);
     }
 }

--- a/src/Config/Communication.php
+++ b/src/Config/Communication.php
@@ -11,9 +11,9 @@ class Communication extends BaseConfig
         return trim((string) $this->config('serverUrl'));
     }
 
-    public function getChannel(): string
+    public function getChannel(?string $salesChannelId = null): string
     {
-        return (string) $this->config('channel');
+        return (string) $this->config('channel', $salesChannelId);
     }
 
     public function getCredentials(): array

--- a/src/Config/FtpConfig.php
+++ b/src/Config/FtpConfig.php
@@ -26,9 +26,9 @@ class FtpConfig extends BaseConfig
         return (string) $this->config('ftpPassword');
     }
 
-    public function getUploadFileName(): string
+    public function getUploadFileName(?string $salesChannelId = null): string
     {
-        return sprintf('export.%s.csv', $this->config('channel'));
+        return sprintf('export.%s.csv', $this->config('channel', $salesChannelId));
     }
 
     public function getPushImportTypes(): array

--- a/src/Upload/UploadService.php
+++ b/src/Upload/UploadService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\Upload;
 
 use Omikron\FactFinder\Shopware6\Config\FtpConfig;
+use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
 use Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory;
 
 class UploadService
@@ -15,16 +16,24 @@ class UploadService
     /** @var FilesystemFactory */
     private $filesystemFactory;
 
-    public function __construct(FtpConfig $config, FilesystemFactory $filesystemFactory)
-    {
-        $this->config            = $config;
-        $this->filesystemFactory = $filesystemFactory;
+    /** @var SalesChannelService */
+    private $salesChannelService;
+
+    public function __construct(
+        FtpConfig $config,
+        FilesystemFactory $filesystemFactory,
+        SalesChannelService $salesChannelService
+    ) {
+        $this->config              = $config;
+        $this->filesystemFactory   = $filesystemFactory;
+        $this->salesChannelService = $salesChannelService;
     }
 
     public function upload($fileHandle): void
     {
-        $connection = $this->filesystemFactory->factory($this->config());
-        $connection->putStream($this->config->getUploadFileName(), $fileHandle);
+        $connection     = $this->filesystemFactory->factory($this->config());
+        $salesChannelId = $this->salesChannelService->getSalesChannelContext()->getSalesChannel()->getId();
+        $connection->putStream($this->config->getUploadFileName($salesChannelId), $fileHandle);
     }
 
     private function config(): array


### PR DESCRIPTION
- Description: 
If you run export wit `-u` flag and other than default sales channel, then exported file will be uploaded to the FTP server with a name containing FACT-Finder channel configured for default channel, not the chosen one. Fix allows to pass sales channel id as a parameter to config functions in order to get stored values in a correct scope
- Tested with Shopware6 editions/versions: 
6.4
- Tested with PHP versions: 
7.4

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
