### PR TITLE
FFWEB-2195: set search immediate for category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 ### Add
 ## Unreleased
  - Category
-    - Add `use ff-communication/search-immediate` field, which set `search-immediate=true` in given category page
-
+    - Add `Disable ff-communication/search-immediate` field, which prevents setting `search-immediate=true` in `ff-communication` on selected category page
 
 ### Fix
  - Export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Changelog
-
+### Add
 ## Unreleased
-### Fix
- - Custom export types, defined by user, are also visible in the export type selector in export form
+ - Category
+    - Add `use ff-communication/search-immediate` field, which set `search-immediate=true` in given category page
 
+
+### Fix
+ - Export
+    - Custom export types, defined by user, are not visible in the entity type selector in the export form
+ - Category
+    - Fix CustomField `Include in FACT-Finder® CMS Export` is always rendered as selected 
+ 
 ## [v2.0.0] - 2021.08.26
 ### Breaking
  - IMPORTANT! Drop Shopware 6.3 compatibility
@@ -31,7 +38,6 @@
  - Fix Export Settings might cause an error on fresh installation of plugin
  - Fix ASN styles which might have affected mobile viewport
  - Fix communication parameters rendering by applying a default filter with empty array 
- - Fix CustomField `Include in FACT-Finder® CMS Export` is always rendered as selected
 
 ## [v1.1.0] - 2021.07.08
 ### Add

--- a/spec/Subscriber/CategoryViewSpec.php
+++ b/spec/Subscriber/CategoryViewSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Omikron\FactFinder\Shopware6\Subscriber;
 
 use Omikron\FactFinder\Shopware6\Export\Field\CategoryPath;
@@ -14,22 +16,21 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Storefront\Page\Navigation\NavigationPage;
 use Shopware\Storefront\Page\Navigation\NavigationPageLoadedEvent;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class CategoryViewSpec extends ObjectBehavior
 {
-    function let(
-        AbstractCategoryRoute     $cmsPageRoute,
-        CategoryPath              $categoryPath,
+    public function let(
+        AbstractCategoryRoute $cmsPageRoute,
+        CategoryPath $categoryPath,
         NavigationPageLoadedEvent $event,
-        Request                   $request,
-        CategoryEntity            $categoryEntity,
-        NavigationPage            $navigationPage,
-        Struct                    $extension,
-        SalesChannelContext       $salesChannelContext,
-        SalesChannelEntity        $salesChannelEntity,
-        CategoryRouteResponse     $categoryRouteResponse)
+        Request $request,
+        CategoryEntity $categoryEntity,
+        NavigationPage $navigationPage,
+        Struct $extension,
+        SalesChannelContext $salesChannelContext,
+        SalesChannelEntity $salesChannelEntity,
+        CategoryRouteResponse $categoryRouteResponse)
     {
         $navigationId = '1';
         $event->getRequest()->willReturn($request);
@@ -50,30 +51,29 @@ class CategoryViewSpec extends ObjectBehavior
         $this->beConstructedWith($cmsPageRoute, $categoryPath, 'CategoryPath, []');
     }
 
-    function it_will_not_add_search_immediate_attribute_if_its_disabled_in_category_config(
-        CategoryEntity            $categoryEntity,
-        Struct                    $extension,
+    public function it_will_not_add_search_immediate_attribute_if_its_disabled_in_category_config(
+        CategoryEntity $categoryEntity,
+        Struct $extension,
         NavigationPageLoadedEvent $event
     ) {
-        $categoryEntity->getCustomFields()->willReturn([OmikronFactFinder::USE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME => false]);
-        $extension->assign(Argument::withEntry('communication', Argument::withEntry('search-immediate', 'false')))->shouldBeCalled();
-        $this->onPageLoaded($event);
-    }
-
-    function it_will_add_search_immediate_attribute_if_its_enabled_in_category_config(
-        CategoryEntity            $categoryEntity,
-        Struct                    $extension,
-        NavigationPageLoadedEvent $event
-    ) {
-
-        $categoryEntity->getCustomFields()->willReturn([OmikronFactFinder::USE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME => true]);
+        $categoryEntity->getCustomFields()->willReturn([OmikronFactFinder::DISABLE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME => false]);
         $extension->assign(Argument::withEntry('communication', Argument::withEntry('search-immediate', 'true')))->shouldBeCalled();
         $this->onPageLoaded($event);
     }
 
-    function it_will_not_fail_if_ff_cms_use_search_immediate_is_not_present_in_custom_fields(
-        CategoryEntity            $categoryEntity,
-        Struct                    $extension,
+    public function it_will_add_search_immediate_attribute_if_its_enabled_in_category_config(
+        CategoryEntity $categoryEntity,
+        Struct $extension,
+        NavigationPageLoadedEvent $event
+    ) {
+        $categoryEntity->getCustomFields()->willReturn([OmikronFactFinder::DISABLE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME => true]);
+        $extension->assign(Argument::withEntry('communication', Argument::withEntry('search-immediate', 'false')))->shouldBeCalled();
+        $this->onPageLoaded($event);
+    }
+
+    public function it_will_not_fail_if_ff_cms_use_search_immediate_is_not_present_in_custom_fields(
+        CategoryEntity $categoryEntity,
+        Struct $extension,
         NavigationPageLoadedEvent $event
     ) {
         $categoryEntity->getCustomFields()->willReturn(null);
@@ -81,12 +81,11 @@ class CategoryViewSpec extends ObjectBehavior
         $this->onPageLoaded($event);
     }
 
-    function it_will_encode_category_path_correctly(
-        CategoryEntity            $categoryEntity,
-        Struct                    $extension,
+    public function it_will_encode_category_path_correctly(
+        CategoryEntity $categoryEntity,
+        Struct $extension,
         NavigationPageLoadedEvent $event
     ) {
-
         $categoryEntity->getCustomFields()->willReturn([]);
         $extension->assign(Argument::withEntry('communication', Argument::withEntry('add-params', Argument::containingString('filter=CategoryPath%2C+%5B%5D%3ABooks%2520%2526%2520Sports%2FHome%2520%2526%2520Garden'))))->shouldBeCalled();
         $this->onPageLoaded($event);

--- a/spec/Subscriber/CategoryViewSpec.php
+++ b/spec/Subscriber/CategoryViewSpec.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace spec\Omikron\FactFinder\Shopware6\Subscriber;
+
+use Omikron\FactFinder\Shopware6\Export\Field\CategoryPath;
+use Omikron\FactFinder\Shopware6\OmikronFactFinder;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\SalesChannel\AbstractCategoryRoute;
+use Shopware\Core\Content\Category\SalesChannel\CategoryRouteResponse;
+use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Storefront\Page\Navigation\NavigationPage;
+use Shopware\Storefront\Page\Navigation\NavigationPageLoadedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class CategoryViewSpec extends ObjectBehavior
+{
+    function let(
+        AbstractCategoryRoute     $cmsPageRoute,
+        CategoryPath              $categoryPath,
+        NavigationPageLoadedEvent $event,
+        Request                   $request,
+        CategoryEntity            $categoryEntity,
+        NavigationPage            $navigationPage,
+        Struct                    $extension,
+        SalesChannelContext       $salesChannelContext,
+        SalesChannelEntity        $salesChannelEntity,
+        CategoryRouteResponse     $categoryRouteResponse)
+    {
+        $navigationId = '1';
+        $event->getRequest()->willReturn($request);
+        $event->getSalesChannelContext()->willReturn($salesChannelContext);
+        $salesChannelContext->getSalesChannel()->willReturn($salesChannelEntity);
+        $salesChannelEntity->getNavigationCategoryId()->willReturn($navigationId);
+        $request->get('navigationId', $navigationId)->willReturn($navigationId);
+        $cmsPageRoute->load('1', $request, $salesChannelContext)->willReturn($categoryRouteResponse);
+        $categoryRouteResponse->getCategory()->willReturn($categoryEntity);
+        $categoryEntity->getBreadcrumb()->willReturn(
+            [
+                0 => 'Home',
+                1 => 'Books & Sports',
+                2 => 'Home & Garden',
+            ])->shouldBeCalled();
+        $event->getPage()->willReturn($navigationPage);
+        $navigationPage->getExtension('factfinder')->willReturn($extension);
+        $this->beConstructedWith($cmsPageRoute, $categoryPath, 'CategoryPath, []');
+    }
+
+    function it_will_not_add_search_immediate_attribute_if_its_disabled_in_category_config(
+        CategoryEntity            $categoryEntity,
+        Struct                    $extension,
+        NavigationPageLoadedEvent $event
+    ) {
+        $categoryEntity->getCustomFields()->willReturn([OmikronFactFinder::USE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME => false]);
+        $extension->assign(Argument::withEntry('communication', Argument::withEntry('search-immediate', 'false')))->shouldBeCalled();
+        $this->onPageLoaded($event);
+    }
+
+    function it_will_add_search_immediate_attribute_if_its_enabled_in_category_config(
+        CategoryEntity            $categoryEntity,
+        Struct                    $extension,
+        NavigationPageLoadedEvent $event
+    ) {
+
+        $categoryEntity->getCustomFields()->willReturn([OmikronFactFinder::USE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME => true]);
+        $extension->assign(Argument::withEntry('communication', Argument::withEntry('search-immediate', 'true')))->shouldBeCalled();
+        $this->onPageLoaded($event);
+    }
+
+    function it_will_not_fail_if_ff_cms_use_search_immediate_is_not_present_in_custom_fields(
+        CategoryEntity            $categoryEntity,
+        Struct                    $extension,
+        NavigationPageLoadedEvent $event
+    ) {
+        $categoryEntity->getCustomFields()->willReturn(null);
+        $this->shouldNotThrow()->during('onPageLoaded', [$event]);
+        $this->onPageLoaded($event);
+    }
+
+    function it_will_encode_category_path_correctly(
+        CategoryEntity            $categoryEntity,
+        Struct                    $extension,
+        NavigationPageLoadedEvent $event
+    ) {
+
+        $categoryEntity->getCustomFields()->willReturn([]);
+        $extension->assign(Argument::withEntry('communication', Argument::withEntry('add-params', Argument::containingString('filter=CategoryPath%2C+%5B%5D%3ABooks%2520%2526%2520Sports%2FHome%2520%2526%2520Garden'))))->shouldBeCalled();
+        $this->onPageLoaded($event);
+    }
+}

--- a/src/OmikronFactFinder.php
+++ b/src/OmikronFactFinder.php
@@ -44,6 +44,19 @@ class OmikronFactFinder extends Plugin
                 'customFieldPosition' => 1,
             ],
         ],
+        [
+            'name'   => self::USE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME,
+            'type'   => CustomFieldTypes::BOOL,
+            'config' => [
+                'label'               => [
+                    'en-GB' => 'Use `ff-communication/search-immediate`',
+                    'en-GB' => 'Use `ff-communication/search-immediate`'
+                ],
+                'componentName'       => 'sw-field',
+                'customFieldType'     => CustomFieldTypes::SWITCH,
+                'customFieldPosition' => 2,
+            ],
+        ],
     ];
 
     public function build(ContainerBuilder $container): void

--- a/src/OmikronFactFinder.php
+++ b/src/OmikronFactFinder.php
@@ -26,9 +26,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class OmikronFactFinder extends Plugin
 {
-    public const FACT_FINDER_CUSTOM_FIELD_SET_NAME      = 'cms_export_include';
-    public const CMS_EXPORT_INCLUDE_CUSTOM_FIELD_NAME   = 'ff_cms_export_include';
-    public const USE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME = 'ff_cms_use_search_immediate';
+    public const FACT_FINDER_CUSTOM_FIELD_SET_NAME          = 'cms_export_include';
+    public const CMS_EXPORT_INCLUDE_CUSTOM_FIELD_NAME       = 'ff_cms_export_include';
+    public const DISABLE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME = 'ff_cms_disable_search_immediate';
 
     private array $customFields = [
         [
@@ -45,12 +45,12 @@ class OmikronFactFinder extends Plugin
             ],
         ],
         [
-            'name'   => self::USE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME,
+            'name'   => self::DISABLE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME,
             'type'   => CustomFieldTypes::BOOL,
             'config' => [
                 'label'               => [
-                    'en-GB' => 'Use `ff-communication/search-immediate`',
-                    'en-GB' => 'Use `ff-communication/search-immediate`',
+                    'en-GB' => 'Disable `ff-communication/search-immediate`',
+                    'en-GB' => 'Disable `ff-communication/search-immediate`',
                 ],
                 'componentName'       => 'sw-field',
                 'customFieldType'     => CustomFieldTypes::SWITCH,

--- a/src/OmikronFactFinder.php
+++ b/src/OmikronFactFinder.php
@@ -50,7 +50,7 @@ class OmikronFactFinder extends Plugin
             'config' => [
                 'label'               => [
                     'en-GB' => 'Use `ff-communication/search-immediate`',
-                    'en-GB' => 'Use `ff-communication/search-immediate`'
+                    'en-GB' => 'Use `ff-communication/search-immediate`',
                 ],
                 'componentName'       => 'sw-field',
                 'customFieldType'     => CustomFieldTypes::SWITCH,

--- a/src/Subscriber/CategoryView.php
+++ b/src/Subscriber/CategoryView.php
@@ -43,7 +43,7 @@ class CategoryView implements EventSubscriberInterface
         $navigationId  = $event->getRequest()->get('navigationId', $event->getSalesChannelContext()->getSalesChannel()->getNavigationCategoryId());
         $category      = $this->cmsPageRoute->load($navigationId, $event->getRequest(), $event->getSalesChannelContext())->getCategory();
         $path          = $this->getPath($category);
-        $safeGetByName = fn(?array $collection) => fn(string $name) => is_array($collection) && isset($collection[$name]) && $collection[$name];
+        $safeGetByName = fn (?array $collection) => fn (string $name) => is_array($collection) && isset($collection[$name]) && $collection[$name];
 
         $event->getPage()->getExtension('factfinder')->assign(
             [

--- a/src/Subscriber/CategoryView.php
+++ b/src/Subscriber/CategoryView.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\Subscriber;
 
 use Omikron\FactFinder\Shopware6\Export\Field\CategoryPath;
+use Omikron\FactFinder\Shopware6\OmikronFactFinder;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\SalesChannel\AbstractCategoryRoute;
 use Shopware\Storefront\Page\Navigation\NavigationPageLoadedEvent;
@@ -39,13 +40,15 @@ class CategoryView implements EventSubscriberInterface
 
     public function onPageLoaded(NavigationPageLoadedEvent $event): void
     {
-        $navigationId = $event->getRequest()->get('navigationId', $event->getSalesChannelContext()->getSalesChannel()->getNavigationCategoryId());
-        $category     = $this->cmsPageRoute->load($navigationId, $event->getRequest(), $event->getSalesChannelContext())->getCategory();
-        $path         = $this->getPath($category);
+        $navigationId  = $event->getRequest()->get('navigationId', $event->getSalesChannelContext()->getSalesChannel()->getNavigationCategoryId());
+        $category      = $this->cmsPageRoute->load($navigationId, $event->getRequest(), $event->getSalesChannelContext())->getCategory();
+        $path          = $this->getPath($category);
+        $safeGetByName = fn(?array $collection) => fn(string $name) => is_array($collection) && isset($collection[$name]) && $collection[$name];
+
         $event->getPage()->getExtension('factfinder')->assign(
             [
                 'communication' => [
-                    'search-immediate' => 'true',
+                    'search-immediate' => $safeGetByName($category->getCustomFields())(OmikronFactFinder::USE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME) ? 'true' : 'false',
                     'add-params'       => $path ? implode(',', $this->initial + [sprintf('filter=%s', urlencode($this->fieldName . ':' . $path))]) : '',
                 ],
             ]);

--- a/src/Subscriber/CategoryView.php
+++ b/src/Subscriber/CategoryView.php
@@ -48,7 +48,7 @@ class CategoryView implements EventSubscriberInterface
         $event->getPage()->getExtension('factfinder')->assign(
             [
                 'communication' => [
-                    'search-immediate' => $safeGetByName($category->getCustomFields())(OmikronFactFinder::USE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME) ? 'true' : 'false',
+                    'search-immediate' => $safeGetByName($category->getCustomFields())(OmikronFactFinder::DISABLE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME) ? 'false' : 'true',
                     'add-params'       => $path ? implode(',', $this->initial + [sprintf('filter=%s', urlencode($this->fieldName . ':' . $path))]) : '',
                 ],
             ]);


### PR DESCRIPTION
- Description: 
Adds custom field for Category Entity which allows to set search-immediate on given category page
- Tested with Shopware6 editions/versions: 
6.4
- Tested with PHP versions:
- 7.4
