### PR TITLE
FFWEB-2212: Fix page builder bug with infinite-scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # Changelog
-### Add
 ## Unreleased
  - Category
     - Add `Disable ff-communication/search-immediate` field, which prevents setting `search-immediate=true` in `ff-communication` on selected category page
 
 ### Fix
  - Export
-    - Custom export types, defined by user, are not visible in the entity type selector in the export form
- - Category
-    - Fix CustomField `Include in FACT-Finder® CMS Export` is always rendered as selected 
- 
+    - Custom export types, defined by user, are also visible in the export type selector in export form
+ - Page Builder
+    - infinite-scrolling is always set to true
+    - infinite-debounce-delay is always set to true with incorrect value
+ - Configuration
+  - Fix Category CustomField `Include in FACT-Finder® CMS Export` is always rendered as selected
+
 ## [v2.0.0] - 2021.08.26
 ### Breaking
  - IMPORTANT! Drop Shopware 6.3 compatibility

--- a/src/Resources/views/storefront/components/factfinder/record-list.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/record-list.html.twig
@@ -3,7 +3,7 @@
     {% if id %} id="{{ id }}" {% endif %}
     class="{{ class }}"
     subscribe="{{ subscribe ? 'true' : 'false' }}"
-    {{ infiniteScrolling ? 'infinite-scrolling' : '' }} {{ infiniteScrolling ? "infinite-debounce-delay=#{infiniteDebounceDelay}" : '' }}
+    {{ infiniteScrolling ? 'infinite-scrolling infinite-debounce-delay=#{infiniteDebounceDelay}' : '' }}
     unresolved>
     {% block component_factfinder_record %}
       <ff-record class="cms-listing-col col-sm-6 col-lg-4 col-xl-3">

--- a/src/Resources/views/storefront/components/factfinder/record-list.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/record-list.html.twig
@@ -3,8 +3,7 @@
     {% if id %} id="{{ id }}" {% endif %}
     class="{{ class }}"
     subscribe="{{ subscribe ? 'true' : 'false' }}"
-    {{ infiniteScrolling ? 'infinite-scrolling' : '' }}
-    {{ infiniteScrolling ? "infinite-debounce-delay=#{infiniteDebounceDelay}" : '' }}
+    {{ infiniteScrolling ? 'infinite-scrolling' : '' }} {{ infiniteScrolling ? "infinite-debounce-delay=#{infiniteDebounceDelay}" : '' }}
     unresolved>
     {% block component_factfinder_record %}
       <ff-record class="cms-listing-col col-sm-6 col-lg-4 col-xl-3">

--- a/src/Resources/views/storefront/components/factfinder/record-list.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/record-list.html.twig
@@ -2,7 +2,9 @@
   <ff-record-list
     {% if id %} id="{{ id }}" {% endif %}
     class="{{ class }}"
-    subscribe="{{ subscribe ? 'true' : 'false' }}" {{ infiniteScrolling ? 'infinite-scrolling' : '' }} {{ infiniteScrolling ? 'infinite-debounce-delay="infiniteDebounceDelay"' : '' }}
+    subscribe="{{ subscribe ? 'true' : 'false' }}"
+    {{ infiniteScrolling ? 'infinite-scrolling' : '' }}
+    {{ infiniteScrolling ? "infinite-debounce-delay=#{infiniteDebounceDelay}" : '' }}
     unresolved>
     {% block component_factfinder_record %}
       <ff-record class="cms-listing-col col-sm-6 col-lg-4 col-xl-3">

--- a/src/Resources/views/storefront/element/cms-element-record-list.html.twig
+++ b/src/Resources/views/storefront/element/cms-element-record-list.html.twig
@@ -4,8 +4,8 @@
 
   {% sw_include '@Parent/storefront/components/factfinder/record-list.html.twig' with {
     subscribe: config.subscribe,
-    infiniteScrolling: config.infiniteScrolling,
-    infiniteDebounceDelay: config.infiniteDebounceDelay,
+    infiniteScrolling: config.infiniteScrolling.value,
+    infiniteDebounceDelay: config.infiniteDebounceDelay.value,
     class: 'row cms-listing-row',
     id: id
   } %}


### PR DESCRIPTION
- Description: 
The values `infinite-scrolling` and `infinite-debounce-delay` are passed incorrectly from the PageBuilder configuration to the template. In result `infinite-scrolling` is always enabled, even thought it should not, and `infinite-debounce-delay` is also enabled and rendered with incorrect value
- Tested with Shopware6 editions/versions: 
6.4
- Tested with PHP versions: 
8.0

