### PR TITLE
FFWEB-2214: Add missing use statement to solve breaked feed export

### DIFF
--- a/src/Export/Field/Price.php
+++ b/src/Export/Field/Price.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\Export\Field;
 
 use Omikron\FactFinder\Shopware6\Export\Formatter\NumberFormatter;
-use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 
 class Price implements FieldInterface
 {
@@ -24,7 +24,7 @@ class Price implements FieldInterface
 
     public function getValue(Entity $entity): string
     {
-        return $this->numberFormatter->format((float) $entity->getCalculatedPrice()->getTotalPrice());
+        return $this->numberFormatter->format((float)$entity->getCalculatedPrice()->getTotalPrice());
     }
 
     public function getCompatibleEntityTypes(): array

--- a/src/Export/Field/Price.php
+++ b/src/Export/Field/Price.php
@@ -6,6 +6,7 @@ namespace Omikron\FactFinder\Shopware6\Export\Field;
 
 use Omikron\FactFinder\Shopware6\Export\Formatter\NumberFormatter;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
 
 class Price implements FieldInterface
 {

--- a/src/Export/Field/Price.php
+++ b/src/Export/Field/Price.php
@@ -24,7 +24,7 @@ class Price implements FieldInterface
 
     public function getValue(Entity $entity): string
     {
-        return $this->numberFormatter->format((float)$entity->getCalculatedPrice()->getTotalPrice());
+        return $this->numberFormatter->format((float) $entity->getCalculatedPrice()->getTotalPrice());
     }
 
     public function getCompatibleEntityTypes(): array


### PR DESCRIPTION
- Solves issue: 
[FFWEB-2214](https://jira.omikron.net/browse/FFWEB-2214)

- Description:
Customer reports that product export doesn't work correctly on shopware versions 6.4.4.0 and higher

- Tested with Shopware6 editions/versions: 
6.4.3.1/6.4.5.0

- Tested with PHP versions: 
7.4.20
