### PR TITLE
FFWEB-2249: Fix configuration subscriber does not get channel with salesChannelId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+  - Config
+    - Configuration is not taking sales channel id argument into account when load the FACT-Finder channel
+
 ## [v2.1.1] - 2021.10.05
 ### Fix
  - Export

--- a/spec/Config/CommunicationSpec.php
+++ b/spec/Config/CommunicationSpec.php
@@ -17,6 +17,15 @@ class CommunicationSpec extends ObjectBehavior
         $this->getCredentials()->shouldContainOnlyStrings();
     }
 
+    function it_should_return_factfinder_channel_configured_for_specific_saleschannel(SystemConfigService $configService)
+    {
+        $configService->get('OmikronFactFinder.config.channel', '1')->willReturn('channel_1');
+        $configService->get('OmikronFactFinder.config.channel', '2')->willReturn('channel_2');
+
+        $this->getChannel('1')->shouldReturn('channel_1');
+        $this->getChannel('2')->shouldReturn('channel_2');
+    }
+
     public function getMatchers(): array
     {
         return [

--- a/spec/Subscriber/ConfigurationSubscriberSpec.php
+++ b/spec/Subscriber/ConfigurationSubscriberSpec.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Omikron\FactFinder\Shopware6\Subscriber;
+
+use Omikron\FactFinder\Shopware6\Config\Communication;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Prophecy\Argument\Token\LogicalAndToken;
+use Prophecy\Argument\Token\TypeToken;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Storefront\Page\GenericPageLoadedEvent;
+use Shopware\Storefront\Page\Page;
+use Symfony\Component\HttpFoundation\Request;
+
+class ConfigurationSubscriberSpec extends ObjectBehavior
+{
+    function let(Communication $communication)
+    {
+        $fieldRoles              = [];
+        $communicationParameters = [];
+        $communication->getServerUrl()->willReturn('https://factfinder.server.com');
+        $this->beConstructedWith($communication, $fieldRoles, $communicationParameters);
+    }
+
+    function it_will_return_factfinderchannel_for_specific_sales_channel_id(
+        Communication          $communication,
+        GenericPageLoadedEvent $event,
+        SalesChannelContext    $salesChannelContext,
+        SalesChannelEntity     $salesChannel,
+        CustomerEntity         $customer,
+        CurrencyEntity         $currency,
+        Request                $request,
+        Struct                 $extension,
+        Page                   $page
+    ) {
+        $event->getSalesChannelContext()->willReturn($salesChannelContext);
+        $salesChannelContext->getCustomer()->willReturn($customer);
+        $customer->getId()->willReturn(1);
+        $salesChannelContext->getCurrency()->willReturn($currency);
+        $currency->getIsoCode()->willReturn('EUR');
+        $salesChannelContext->getSalesChannel()->willReturn($salesChannel);
+        $salesChannel->getId()->willReturn('main_sales_channel');
+        $communication->getChannel('main_sales_channel')->willReturn('some_ff_channel');
+        $event->getRequest()->willReturn($request);
+        $request->get('_route')->willReturn('factfinder');
+        $request->getLocale()->willReturn('en');
+        $event->getPage()->willReturn($page);
+
+        $page->addExtension(
+            'factfinder',
+            new LogicalAndToken(
+                [
+                    new TypeToken(ArrayEntity::class),
+                    Argument::withEntry('communication', Argument::withEntry('channel', 'some_ff_channel'))
+                ]
+            ))->shouldBeCalled();
+
+        $this->onPageLoaded($event);
+    }
+}

--- a/src/Subscriber/ConfigurationSubscriber.php
+++ b/src/Subscriber/ConfigurationSubscriber.php
@@ -31,12 +31,14 @@ class ConfigurationSubscriber implements EventSubscriberInterface
 
     public function onPageLoaded(GenericPageLoadedEvent $event): void
     {
-        $customer = $event->getSalesChannelContext()->getCustomer();
+        $customer       = $event->getSalesChannelContext()->getCustomer();
+        $salesChannelId = $event->getSalesChannelContext()->getSalesChannel()->getId();
+
         $event->getPage()->addExtension('factfinder', new ArrayEntity([
             'field_roles'   => $this->fieldRoles,
             'communication' => [
                 'url'                   => $this->config->getServerUrl(),
-                'channel'               => $this->config->getChannel(),
+                'channel'               => $this->config->getChannel($salesChannelId),
                 'version'               => 'ng',
                 'api'                   => 'v4',
                 'user-id'               => $customer ? $customer->getId() : null,


### PR DESCRIPTION
- Description: 
ConfigurationSubscriber does not get FACT-Finder channel from correct salesChannel context
- Tested with Shopware6 editions/versions: 
6.4
- Tested with PHP versions: 
7.4
