### PR TITLE
FFWEB-2443: Add Layout column to CMS export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
+## [Unreleased]
+### Add 
+ - Export
+  - Added new field provider `Omikron\FactFinder\Shopware6\Export\Field\Layout` applicable to CMS Export
+  
 ## [v3.0.1] - 2022.03.10
-
 ### Fix
  - `Omikron\FactFinder\Shopware6\Subscriber\CategoryView`
   - fix category path is not encoded correctly 

--- a/spec/Export/Field/LayoutSpec.php
+++ b/spec/Export/Field/LayoutSpec.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Omikron\FactFinder\Shopware6\Export\Field;
+
+use Omikron\FactFinder\Shopware6\Export\Filter\TextFilter;
+use PhpSpec\ObjectBehavior;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\CmsPageEntity;
+
+class LayoutSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $this->beConstructedWith(new TextFilter());
+    }
+
+    public function it_should_strip_html_tags(CategoryEntity $categoryEntity): void
+    {
+        $cmsPage = new CmsPageEntity();
+        $cmsPage->setSections(
+            new CmsSectionCollection(
+                [
+                    '1' => $this->createSection(
+                        [
+                            $this->createBlock(
+                                [
+                                    $this->createSlot(['content' => ['value' => '<h2>Lorem Ipsum </h2><p>Dolor sit amet</p>']]),
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            )
+        );
+        $categoryEntity->getCmsPage()->willReturn($cmsPage);
+        $this->getValue($categoryEntity)->shouldReturn('Lorem Ipsum Dolor sit amet');
+    }
+
+    public function it_should_concatenate_values_from_all_slots_configs(CategoryEntity $categoryEntity): void
+    {
+        $cmsPage = new CmsPageEntity();
+        $cmsPage->setSections(
+            new CmsSectionCollection(
+                [
+                    '1' => $this->createSection(
+                        [
+                            $this->createBlock(
+                                [
+                                    $this->createSlot(['content' => ['value' => 'I am']]),
+                                ], 1
+                            ),
+                        ],
+                    ),
+                    '2' => $this->createSection(
+                        [
+                            $this->createBlock(
+                                [
+                                    $this->createSlot(['content' => ['value' => 'concatenated']]),
+                                ], 2
+                            ),
+                        ], 2
+                    ),
+                ]
+            )
+        );
+        $categoryEntity->getCmsPage()->willReturn($cmsPage);
+        $this->getValue($categoryEntity)->shouldReturn('I am concatenated');
+    }
+
+    public function it_should_sort_output_by_position(CategoryEntity $categoryEntity): void
+    {
+        $cmsPage = new CmsPageEntity();
+        $cmsPage->setSections(
+            new CmsSectionCollection(
+                [
+                    '1' => $this->createSection(
+                        [
+                            $this->createBlock(
+                                [
+                                    $this->createSlot(['content' => ['value' => 'not']]),
+                                ], 2
+                            ),
+                            $this->createBlock(
+                                [
+                                    $this->createSlot(['content' => ['value' => 'Yoda']]),
+                                ],
+                                3
+                            ),
+                            $this->createBlock(
+                                [
+                                    $this->createSlot(['content' => ['value' => 'I am']]),
+                                ], 1
+                            ),
+                        ]
+                    ),
+                ]
+            )
+        );
+
+        $categoryEntity->getCmsPage()->willReturn($cmsPage);
+        $this->getValue($categoryEntity)->shouldReturn('I am not Yoda');
+    }
+
+    private function createSection(array $blocks, int $position = 1): CmsSectionEntity
+    {
+        $section = new CmsSectionEntity();
+        $section->setId(uniqid());
+        $section->setPosition($position);
+        $section->setBlocks(new CmsBlockCollection($blocks));
+        return $section;
+    }
+
+    private function createBlock(array $slots, int $position = 1): CmsBlockEntity
+    {
+        $block = new CmsBlockEntity();
+        $block->setId(uniqid());
+        $block->setPosition($position);
+        $block->setSlots(new CmsSlotCollection($slots));
+        return $block;
+    }
+
+    private function createSlot(array $config): CmsSlotEntity
+    {
+        $slot = new CmsSlotEntity();
+        $slot->setId(uniqid());
+        $slot->setSlot(uniqid('slot-'));
+        $slot->setConfig($config);
+        return $slot;
+    }
+}

--- a/src/Export/ExportCategories.php
+++ b/src/Export/ExportCategories.php
@@ -54,6 +54,10 @@ class ExportCategories implements ExportInterface
         $criteria->addAssociation('customFields');
         $criteria->addAssociation('media');
         $criteria->addAssociation('seoUrls');
+        $criteria->addAssociation('cmsPage.sections');
+        $criteria->addAssociation('cmsPage.sections.blocks');
+        $criteria->addAssociation('cmsPage.sections.blocks.slots');
+        $criteria->addAssociation('slotConfig');
         foreach ($this->customAssociations as $association) {
             $criteria->addAssociation($association);
         }

--- a/src/Export/Field/Deeplink.php
+++ b/src/Export/Field/Deeplink.php
@@ -45,7 +45,7 @@ class Deeplink implements FieldInterface, EventSubscriberInterface
         if (!$url) {
             $this->seoUrlUpdater->update($getSeoUrlRouteName($entity), [$entity->getId()]);
             $seoUrls = call_user_func($this->fetchCallback);
-            return $formUrl((string) safeGetByName($seoUrls)('seoPathInfo'));
+            return $formUrl((string) safeGetByName($seoUrls, 'seoPathInfo'));
         }
         return $formUrl($url->getSeoPathInfo());
     }

--- a/src/Export/Field/Layout.php
+++ b/src/Export/Field/Layout.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export\Field;
+
+use Omikron\FactFinder\Shopware6\Export\Filter\TextFilter;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use function Omikron\FactFinder\Shopware6\Internal\Utils\flatMap;
+use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;
+
+class Layout implements FieldInterface
+{
+    private TextFilter $textFilter;
+
+    public function __construct(TextFilter $textFilter)
+    {
+        $this->textFilter = $textFilter;
+    }
+
+    public function getName(): string
+    {
+        return 'Layout';
+    }
+
+    /**
+     * @param CategoryEntity $entity
+     *
+     * @return string
+     */
+    public function getValue(Entity $entity): string
+    {
+        $layout = array_map(
+            fn (CmsSlotEntity $slot) => safeGetByName(safeGetByName($slot->getConfig(), 'content'), 'value'),
+            flatMap(
+                fn (CmsBlockEntity $block): array => $this->toValues($block->getSlots()),
+                flatMap(
+                    fn (CmsSectionEntity $section): array => $this->toValues($section->getBlocks()),
+                    $this->toValues($entity->getCmsPage()->getSections())
+                )
+            )
+        );
+
+        return $this->textFilter->filterValue(implode(' ', array_filter($layout)));
+    }
+
+    public function getCompatibleEntityTypes(): array
+    {
+        return [CategoryEntity::class];
+    }
+
+    private function toValues(EntityCollection $collection): array
+    {
+        /**
+         * @param CmsBlockEntity|CmsSectionEntity $current
+         * @param CmsBlockEntity|CmsSectionEntity $next
+         *
+         * @return bool
+         */
+        $sortByPosition = fn ($current, $next): bool => !method_exists($current, 'getPosition') || $current->getPosition() > $next->getPosition();
+        $collection->sort($sortByPosition);
+
+        return array_values($collection->getElements());
+    }
+}

--- a/src/Internal/utils.php
+++ b/src/Internal/utils.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Internal\Utils;
 
-use Closure;
-
-function safeGetByName(?array $collection): Closure
+/**
+ * @param array|null $collection
+ * @param string     $name
+ *
+ * @return mixed|null
+ */
+function safeGetByName(?array $collection, string $name)
 {
-    return fn (string $name): ?string => isset($collection[$name]) ? (string) $collection[$name] : null;
+    return $collection[$name] ?? null;
 }
 
 function flatMap(callable $fnc, array $arr, array ...$arrays): array
@@ -16,6 +20,12 @@ function flatMap(callable $fnc, array $arr, array ...$arrays): array
     return array_merge([], ...array_map($fnc, $arr, ...$arrays));
 }
 
+/**
+ * @param array|null $collection
+ * @param null       $default
+ *
+ * @return false|mixed|null
+ */
 function first(?array $collection, $default = null)
 {
     return empty($collection) ? $default : reset($collection);

--- a/src/Subscriber/CategoryPageSubscriber.php
+++ b/src/Subscriber/CategoryPageSubscriber.php
@@ -44,11 +44,11 @@ class CategoryPageSubscriber implements EventSubscriberInterface
         $navigationId = $event->getRequest()->get('navigationId', $event->getSalesChannelContext()->getSalesChannel()->getNavigationCategoryId());
         $category     = $this->cmsPageRoute->load($navigationId, $event->getRequest(), $event->getSalesChannelContext())->getCategory();
 
-        $disableImmediate = safeGetByName($category->getCustomFields())(OmikronFactFinder::DISABLE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME);
+        $disableImmediate = safeGetByName($category->getCustomFields(), OmikronFactFinder::DISABLE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME);
         $isHome           = $event->getRequest()->get('_route') === 'frontend.home.page';
         $searchImmediate  = !$isHome && !$disableImmediate;
 
-        $baseAddParams   = array_filter(explode(',', (string) safeGetByName($event->getPage()->getExtension('factfinder')->get('communication'))('add-params')));
+        $baseAddParams = array_filter(explode(',', (string) safeGetByName($event->getPage()->getExtension('factfinder')->get('communication'), 'add-params')));
         /**
          * $this->addParams + $baseAddParams will not override entries from $baseAddParams as $this->addParams is associative array and $baseAddParams is not
          * $this->addParams is associative array because this is how parameters collection is passed as an argument constructor in Symfony.


### PR DESCRIPTION
- Description: 
  - Add Layout column to CMS export
- Tested with Shopware6 editions/versions: 
  - 6.4.9
- Tested with PHP versions: 
  - 7.4
