### PR TITLE
FFWEB-2745 Fix image url is not exported for variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fix
+ - Export
+  - fix ImageUrl has not been exported for variants
+    
 ## [v3.1.0] - 2022.03.28
 ### Add 
  - Export

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -37,7 +37,7 @@
             <parameter key="trackingProductNumber">ProductNumber</parameter>
         </parameter>
         <parameter key="factfinder.export.associations" type="collection">
-            <parameter key="variant_cover">children.cover</parameter>
+            <parameter key="variant_cover">children.media</parameter>
         </parameter>
         <parameter key="factfinder.navigation.category_path_field_name" type="string">CategoryPath</parameter>
         <parameter key="factfinder.category_page.add_params" type="collection"></parameter>


### PR DESCRIPTION
- Solves issue: 
- fix `ImageUrl` does not export variants images as wrong association is used 
- Tested with Shopware6 editions/versions: 
6.4.9999999.9999999 Developer Version
- Tested with PHP versions: 
8.0
