### PR TITLE
FFWEB-2539: Cache preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,10 +570,10 @@ class FeedPreprocessorEntryBeforeCreateSubscriber implements EventSubscriberInte
 
     public function onCreateEntries(FeedPreprocessorEntryBeforeCreate $event)
     {
-        $event->getEntry()->setAdditionalCache([
+        $event->getEntry()['additionalCache'] = [
             'some_data' => 'cache1',
             'some_data2' => 'cache2',
-        ]);
+        ];
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -570,10 +570,12 @@ class FeedPreprocessorEntryBeforeCreateSubscriber implements EventSubscriberInte
 
     public function onCreateEntries(FeedPreprocessorEntryBeforeCreate $event)
     {
-        $event->getEntry()['additionalCache'] = [
+        $entry = $event->getEntry();
+        $entry['additionalCache'] = [
             'some_data' => 'cache1',
             'some_data2' => 'cache2',
         ];
+        $event->setEntry($entry);
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ final chapter *Exporting Feed* describes how to use provided console command to 
     - [Extending Specific Web Component Template](#extending-specific-web-component-template)
     - [Split ASN on Category Page](#split-asn-on-category-page)
     - [Set custom Field Roles](#set-custom-field-roles)
+    - [Adding custom Export Cache Subscriber](#adding-custom-export-cache-subscriber)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -108,6 +109,10 @@ You can find more information about what Field Roles are in (Web Components docu
   default, all custom fields are being exported.
 * Export prices for all Currencies - if disabled, export will contain only one column `Price`. If enabled, all product
   price will be exported in all currency configured for a given sales channel.
+* Enable export cache - if enabled export time will be shorter. Option is connected with `Storefron presentation` - 
+  it means that each `Product listing` will be cached. During building cache `FeedPreprocessorEntryBeforeCreate` 
+  event is triggered, so you can easily hook to it if you would like to cache some additional data. You can find more 
+  details about implementation [here](#adding-custom-export-cache-subscriber).
 
 #### Price Columns Format
 
@@ -548,6 +553,33 @@ Default field roles are defined as array of Symfony Configuration Parameters in 
     </parameter>
 
 In order to override these parameters defined by a module, you have to redefine them in your application `services.xml`. Parameters defined there take precedence over the defaults, defined in the module   
+
+### Adding custom Export Cache Subscriber
+
+```php
+
+use Omikron\FactFinder\Shopware6\Events\FeedPreprocessorEntryBeforeCreate;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class FeedPreprocessorEntryBeforeCreateSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [FeedPreprocessorEntryBeforeCreate::class => 'onCreateEntries'];
+    }
+
+    public function onCreateEntries(FeedPreprocessorEntryBeforeCreate $event)
+    {
+        $event->getEntry()->setAdditionalCache([
+            'some_data' => 'cache1',
+            'some_data2' => 'cache2',
+        ]);
+    }
+}
+
+```
+
+
 ## Contribute
 
 We welcome contribution! For more information, click [here](.github/CONTRIBUTING.md)

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "3.1",
     "phpmd/phpmd": "^2.9",
-    "phpspec/phpspec": "^6.2"
+    "phpspec/phpspec": "^6.2",
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
+++ b/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
@@ -91,6 +91,29 @@ class FeedPreprocessorSpec extends ObjectBehavior
         );
     }
 
+    function it_should_create_entries_with_empty_string_in_custom_fields_when_custom_fields_not_set()
+    {
+        // Given
+        $productEntity = $this->productMockFactory->create();
+        $productEntity->setMainVariantId('SW100');
+        $variant = $this->variantMockFactory->create(
+            $productEntity,
+            ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'red', 'material' => 'cotton', 'customFields' => '']
+        );
+        $productEntity->setChildren(new ProductCollection([$variant]));
+
+        // Expect
+        $this->customFields->getValue($variant)->willReturn('');
+
+        // When
+        $entries = $this->createEntries($productEntity, $this->context);
+        $entries->shouldBeArray();
+        $entries->shouldHaveCount(1);
+
+        // Then
+        Assert::assertEquals('', array_values($entries->getWrappedObject())[0]['customFields']);
+    }
+
     function it_should_create_entries_with_proper_custom_fields_for_each_display_group()
     {
         $this->validateCustomFields(

--- a/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
+++ b/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Omikron\FactFinder\Shopware6\DataAbstractionLayer;
+
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Omikron\FactFinder\Shopware6\Export\Field\CustomFields as ExportCustomFields;
+use Omikron\FactFinder\Shopware6\Export\Filter\TextFilter;
+use Omikron\FactFinder\Shopware6\Export\PropertyFormatter;
+use Omikron\FactFinder\Shopware6\TestUtil\ProductMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\ProductVariantMockFactory;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Subject;
+use PHPUnit\Framework\Assert;
+use Prophecy\Argument;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+use PhpSpec\Wrapper\Collaborator;
+
+class FeedPreprocessorSpec extends ObjectBehavior
+{
+    private ProductMockFactory $productMockFactory;
+    private ProductVariantMockFactory $variantMockFactory;
+    private Collaborator $customFields;
+
+    function let(EventDispatcherInterface $eventDispatcher, ExportCustomFields $customFields)
+    {
+        $eventDispatcher->dispatch(Argument::any())->willReturn(new Event());
+        $this->beConstructedWith(new PropertyFormatter(new TextFilter()), $eventDispatcher, $customFields);
+        $this->setContext(new Context(new SystemSource()));
+        $this->productMockFactory = new ProductMockFactory();
+        $this->variantMockFactory = new ProductVariantMockFactory();
+        $this->customFields = $customFields;
+    }
+
+    function it_should_create_only_entries_for_variants_that_should_be_visible()
+    {
+        $productEntity = $this->productMockFactory->create();
+        $variants      = [
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'red', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'red', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.3', 'size' => 'L', 'color' => 'red', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.4', 'size' => 'S', 'color' => 'blue', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.5', 'size' => 'M', 'color' => 'blue', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.6', 'size' => 'L', 'color' => 'blue', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.7', 'size' => 'S', 'color' => 'green', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.8', 'size' => 'M', 'color' => 'green', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.9', 'size' => 'L', 'color' => 'green', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.10', 'size' => 'S', 'color' => 'red', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.11', 'size' => 'M', 'color' => 'red', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.12', 'size' => 'L', 'color' => 'red', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.13', 'size' => 'S', 'color' => 'blue', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.14', 'size' => 'M', 'color' => 'blue', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.15', 'size' => 'L', 'color' => 'blue', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.16', 'size' => 'S', 'color' => 'green', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.17', 'size' => 'M', 'color' => 'green', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.18', 'size' => 'L', 'color' => 'green', 'material' => 'linen']),
+        ];
+        foreach ($variants as $variant) {
+            $this->customFields->getValue($variant)->willReturn('');
+        }
+
+        $productEntity->setChildren(
+            new ProductCollection(
+                array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array
+                => $carriedVariants + [$product->getId() => $product], [])));
+
+        /** @var Subject $entries */
+        $entries = $this->createEntries($productEntity);
+
+        $entries->shouldBeArray();
+        //3 colors * 2 materials = 6 combinations
+        $entries->shouldHaveCount(6);
+
+        $this->validateFilterAttributes(
+            $entries->getWrappedObject(),
+            [
+                'size=S|size=M|size=L|color=red|material=cotton',
+                'size=S|size=M|size=L|color=blue|material=cotton',
+                'size=S|size=M|size=L|color=green|material=cotton',
+                'size=S|size=M|size=L|color=red|material=linen',
+                'size=S|size=M|size=L|color=blue|material=linen',
+                'size=S|size=M|size=L|color=green|material=linen',
+            ]
+        );
+    }
+
+    function it_should_create_entries_with_proper_custom_fields_for_each_display_group()
+    {
+        $this->validateCustomFields(
+            [
+                [md5('size'), 'true'],
+                [md5('color'), 'false'],
+                [md5('material'), 'false']
+            ],
+            [
+                '|pattern=dots|pattern=stripes|shape=rectangle|shape=square|shape=triangle|',
+                '|pattern=dots|pattern=patterned|pattern=stripes|shape=circle|shape=rectangle|shape=triangle|',
+            ]
+        );
+        $this->validateCustomFields(
+            [
+                [md5('size'), 'false'],
+                [md5('color'), 'true'],
+                [md5('material'), 'false']
+            ],
+            [
+                '|pattern=dots|pattern=patterned|pattern=stripes|shape=square|shape=triangle|',
+                '|pattern=dots|pattern=stripes|shape=circle|shape=rectangle|',
+            ]
+        );
+        $this->validateCustomFields(
+            [
+                [md5('size'), 'false'],
+                [md5('color'), 'true'],
+                [md5('material'), 'true']
+            ],
+            [
+                '|pattern=dots|pattern=stripes|shape=triangle|',
+                '|pattern=dots|pattern=patterned|shape=square|shape=triangle|',
+                '|pattern=dots|pattern=stripes|shape=rectangle|',
+                '|pattern=dots|pattern=stripes|shape=circle|shape=rectangle|',
+            ]
+        );
+        $this->validateCustomFields(
+            [
+                [md5('size'), 'true'],
+                [md5('color'), 'true'],
+                [md5('material'), 'true']
+            ],
+            [
+                '|pattern=stripes|shape=triangle|',
+                '|pattern=dots|shape=triangle|',
+                '|pattern=dots|shape=square|',
+                '|pattern=patterned|shape=triangle|',
+                '|pattern=dots|shape=rectangle|',
+                '|pattern=stripes|shape=rectangle|',
+                '|pattern=dots|shape=rectangle|',
+                '|pattern=stripes|shape=circle|',
+            ]
+        );
+    }
+
+    function it_should_export_only_one_entry_if_main_variant_is_selected()
+    {
+        $productEntity = $this->productMockFactory->create();
+        $productEntity->setMainVariantId('SW100');
+        $customFieldsData = [
+            'SW100.1' => ['shape' => 'triangle', 'pattern' => 'stripes'],
+            'SW100.2' => ['shape' => 'rectangle', 'pattern' => 'patterned'],
+            'SW100.3' => ['shape' => 'square', 'pattern' => 'dots'],
+        ];
+
+        $customFieldsValues = [
+            'SW100.1' => '|shape=triangle|pattern=stripes|',
+            'SW100.2' => '|shape=rectangle|pattern=patterned|',
+            'SW100.3' => '|shape=square|pattern=dots|',
+        ];
+
+        $variants = [
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'red', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.1']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'red', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.1']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.3', 'size' => 'L', 'color' => 'red', 'material' => 'wool', 'customFields' => $customFieldsData['SW100.1']])
+        ];
+
+        foreach ($variants as $variant) {
+            $this->customFields->getValue($variant)->willReturn($customFieldsValues[$variant->getProductNumber()]);
+        }
+
+        $productEntity->setChildren(
+            new ProductCollection(
+                array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array
+                => $carriedVariants + [$product->getId() => $product], [])));
+
+        /** @var Subject $entries */
+        $entries = $this->createEntries($productEntity);
+        $entries->shouldBeArray();
+        //only one entry should be producted
+        $entries->shouldHaveCount(1);
+
+        $this->validateFilterAttributes($entries->getWrappedObject(), [
+            'size=S|size=M|size=L|color=red|material=cotton|material=linen|material=wool'
+        ]);
+
+
+    }
+
+    private function validateFilterAttributes(array $entries, array $filters)
+    {
+        $expected = count($filters);
+        $isContainingFilter = fn(string $filter): callable
+            => fn(FeedPreprocessorEntry $entry): bool
+                => strpos($entry->getFilterAttributes(), $filter) !== false;
+
+        $match = array_reduce($filters, fn (int $score, string $filter)
+            => $score + (int) array_filter($entries, $isContainingFilter($filter)), 0);
+
+        Assert::assertEquals($expected, $match);
+    }
+
+    private function validateCustomFields(array $groupConfigurationConfig, array $expectedValues)
+    {
+        // Given
+        $productMockFactory = new ProductMockFactory();
+        $variantMockFactory = new ProductVariantMockFactory();
+        $productEntity = $productMockFactory->create();
+        $productEntity->setConfiguratorGroupConfig(ProductMockFactory::getGroupConfigurationConfig($groupConfigurationConfig));
+        $customFieldsData = [
+            'SW100.1' => ['shape' => 'triangle', 'pattern' => 'stripes'],
+            'SW100.2' => ['shape' => 'triangle', 'pattern' => 'dots'],
+            'SW100.3' => ['shape' => 'square', 'pattern' => 'dots'],
+            'SW100.4' => ['shape' => 'triangle', 'pattern' => 'patterned'],
+            'SW100.5' => ['shape' => 'rectangle', 'pattern' => 'dots'],
+            'SW100.6' => ['shape' => 'rectangle', 'pattern' => 'stripes'],
+            'SW100.7' => ['shape' => 'rectangle', 'pattern' => 'dots'],
+            'SW100.8' => ['shape' => 'circle', 'pattern' => 'stripes'],
+        ];
+        $customFieldsValues = [
+            'SW100.1' => '|shape=triangle|pattern=stripes|',
+            'SW100.2' => '|shape=triangle|pattern=dots|',
+            'SW100.3' => '|shape=square|pattern=dots|',
+            'SW100.4' => '|shape=triangle|pattern=patterned|',
+            'SW100.5' => '|shape=rectangle|pattern=dots|',
+            'SW100.6' => '|shape=rectangle|pattern=stripes|',
+            'SW100.7' => '|shape=rectangle|pattern=dots|',
+            'SW100.8' => '|shape=circle|pattern=stripes|',
+        ];
+        $variants = [
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'green', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.1']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'green', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.2']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.3', 'size' => 'S', 'color' => 'green', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.3']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.4', 'size' => 'M', 'color' => 'green', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.4']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.5', 'size' => 'S', 'color' => 'red', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.5']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.6', 'size' => 'M', 'color' => 'red', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.6']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.7', 'size' => 'S', 'color' => 'red', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.7']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.8', 'size' => 'M', 'color' => 'red', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.8']]),
+        ];
+        $productEntity->setChildren(new ProductCollection(array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array => $carriedVariants + [$product->getId() => $product], [])));
+
+        // Expected
+        foreach ($variants as $variant) {
+            $this->customFields->getValue($variant)->willReturn($customFieldsValues[$variant->getProductNumber()]);
+        }
+
+        // When
+        $entries = $this->createEntries($productEntity);
+
+        // Then
+        $entries = array_values($entries->getWrappedObject());
+
+        foreach ($expectedValues as $key => $expectedValue) {
+            $gluedCustomFields = explode('|', trim($entries[$key]->getCustomFields(), '|'));
+            sort($gluedCustomFields);
+            $gluedCustomFields = sprintf('|%s|', implode('|', $gluedCustomFields));
+            Assert::assertEquals($expectedValue, $gluedCustomFields);
+        }
+    }
+}

--- a/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
+++ b/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace spec\Omikron\FactFinder\Shopware6\DataAbstractionLayer;
 
-use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
 use Omikron\FactFinder\Shopware6\Export\Field\CustomFields as ExportCustomFields;
 use Omikron\FactFinder\Shopware6\Export\Filter\TextFilter;
 use Omikron\FactFinder\Shopware6\Export\PropertyFormatter;

--- a/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
+++ b/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
@@ -27,12 +27,13 @@ class FeedPreprocessorSpec extends ObjectBehavior
     private ProductMockFactory $productMockFactory;
     private ProductVariantMockFactory $variantMockFactory;
     private Collaborator $customFields;
+    private Context $context;
 
     function let(EventDispatcherInterface $eventDispatcher, ExportCustomFields $customFields)
     {
         $eventDispatcher->dispatch(Argument::any())->willReturn(new Event());
         $this->beConstructedWith(new PropertyFormatter(new TextFilter()), $eventDispatcher, $customFields);
-        $this->setContext(new Context(new SystemSource()));
+        $this->context = new Context(new SystemSource());
         $this->productMockFactory = new ProductMockFactory();
         $this->variantMockFactory = new ProductVariantMockFactory();
         $this->customFields = $customFields;
@@ -71,7 +72,7 @@ class FeedPreprocessorSpec extends ObjectBehavior
                 => $carriedVariants + [$product->getId() => $product], [])));
 
         /** @var Subject $entries */
-        $entries = $this->createEntries($productEntity);
+        $entries = $this->createEntries($productEntity, $this->context);
 
         $entries->shouldBeArray();
         //3 colors * 2 materials = 6 combinations
@@ -178,7 +179,7 @@ class FeedPreprocessorSpec extends ObjectBehavior
                 => $carriedVariants + [$product->getId() => $product], [])));
 
         /** @var Subject $entries */
-        $entries = $this->createEntries($productEntity);
+        $entries = $this->createEntries($productEntity, $this->context);
         $entries->shouldBeArray();
         //only one entry should be producted
         $entries->shouldHaveCount(1);
@@ -248,7 +249,7 @@ class FeedPreprocessorSpec extends ObjectBehavior
         }
 
         // When
-        $entries = $this->createEntries($productEntity);
+        $entries = $this->createEntries($productEntity, $this->context);
 
         // Then
         $entries = array_values($entries->getWrappedObject());

--- a/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
+++ b/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
@@ -195,8 +195,8 @@ class FeedPreprocessorSpec extends ObjectBehavior
     {
         $expected = count($filters);
         $isContainingFilter = fn(string $filter): callable
-            => fn(FeedPreprocessorEntry $entry): bool
-                => strpos($entry->getFilterAttributes(), $filter) !== false;
+            => fn(array $entry): bool
+                => strpos($entry['filterAttributes'], $filter) !== false;
 
         $match = array_reduce($filters, fn (int $score, string $filter)
             => $score + (int) array_filter($entries, $isContainingFilter($filter)), 0);
@@ -255,7 +255,7 @@ class FeedPreprocessorSpec extends ObjectBehavior
         $entries = array_values($entries->getWrappedObject());
 
         foreach ($expectedValues as $key => $expectedValue) {
-            $gluedCustomFields = explode('|', trim($entries[$key]->getCustomFields(), '|'));
+            $gluedCustomFields = explode('|', trim($entries[$key]['customFields'], '|'));
             sort($gluedCustomFields);
             $gluedCustomFields = sprintf('|%s|', implode('|', $gluedCustomFields));
             Assert::assertEquals($expectedValue, $gluedCustomFields);

--- a/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
+++ b/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Omikron\FactFinder\Shopware6\Export\Data\Factory;
 
+use Omikron\FactFinder\Shopware6\Config\ExportSettings;
 use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryReader;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
 use Omikron\FactFinder\Shopware6\Export\Data\Factory\FactoryInterface;
@@ -34,7 +35,8 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
 
     function let(
         FactoryInterface $decoratedFactory,
-        FeedPreprocessorEntryReader $feedPreprocessorReader
+        FeedPreprocessorEntryReader $feedPreprocessorReader,
+        ExportSettings $exportSettings
     ) {
         $this->productMockFactory = new ProductMockFactory();
         $this->variantMockFactory = new ProductVariantMockFactory();
@@ -43,7 +45,7 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
         $this->salesChannelProductMockFactory = new SalesChannelProductMockFactory();
         $this->feedPreprocessorReader = $feedPreprocessorReader;
         $this->decoratedFactory = $decoratedFactory;
-        $this->beConstructedWith($decoratedFactory,  new FieldsProvider(new \ArrayIterator()), $feedPreprocessorReader, $this->cachedFields);
+        $this->beConstructedWith($decoratedFactory,  new FieldsProvider(new \ArrayIterator()), $exportSettings, $feedPreprocessorReader, $this->cachedFields);
     }
 
     public function it_should_handle_entities_without_cache_using_fallback_from_decorated_factory(): void

--- a/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
+++ b/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
@@ -293,7 +293,7 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
     {
         return array_reduce(
             $variantsData,
-            fn(array $acc, array $variantData): array => $acc + [$variantData['productNumber'] => $this->feedPreprocessorEntryMockFactory->create($this->variantMockFactory->create($parent, $variantData), ['filterAttributes' => $variantData['filterAttributes'], 'customFields' => $variantData['customFields']])],
+            fn(array $acc, array $variantData): array => $acc + [$variantData['productNumber'] => $this->feedPreprocessorEntryMockFactory->create($this->variantMockFactory->create($parent, $variantData), ['filterAttributes' => $variantData['filterAttributes'], 'customFields' => $variantData['customFields'] ?? ''])],
             []
         );
     }

--- a/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
+++ b/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
@@ -31,7 +31,7 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
     private SalesChannelProductMockFactory $salesChannelProductMockFactory;
     private Collaborator $decoratedFactory;
     private Collaborator $feedPreprocessorReader;
-    private array $cachedFields = [];
+    private \Traversable $cachedFields;
 
     function let(
         FactoryInterface $decoratedFactory,
@@ -45,6 +45,8 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
         $this->salesChannelProductMockFactory = new SalesChannelProductMockFactory();
         $this->feedPreprocessorReader = $feedPreprocessorReader;
         $this->decoratedFactory = $decoratedFactory;
+        $this->cachedFields = new \ArrayIterator();
+        $exportSettings->isExportCacheEnable()->willReturn(true);
         $this->beConstructedWith($decoratedFactory,  new FieldsProvider(new \ArrayIterator()), $exportSettings, $feedPreprocessorReader, $this->cachedFields);
     }
 

--- a/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
+++ b/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
@@ -8,11 +8,14 @@ use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryReade
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
 use Omikron\FactFinder\Shopware6\Export\Data\Factory\FactoryInterface;
 use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Omikron\FactFinder\Shopware6\Export\FieldsProvider;
 use Omikron\FactFinder\Shopware6\TestUtil\FeedPreprocessorEntryMockFactory;
 use Omikron\FactFinder\Shopware6\TestUtil\ExportProductMockFactory;
 use Omikron\FactFinder\Shopware6\TestUtil\ProductMockFactory;
 use Omikron\FactFinder\Shopware6\TestUtil\ProductVariantMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\SalesChannelProductMockFactory;
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Collaborator;
 use PHPUnit\Framework\Assert;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
@@ -23,19 +26,27 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
     private ProductVariantMockFactory $variantMockFactory;
     private FeedPreprocessorEntryMockFactory $feedPreprocessorEntryMockFactory;
     private ExportProductMockFactory $exportProductMockFactory;
+    private SalesChannelProductMockFactory $salesChannelProductMockFactory;
+    private Collaborator $decoratedFactory;
+    private Collaborator $feedPreprocessorReader;
+    private array $cachedFields = [];
 
-    function let()
-    {
+    function let(
+        FactoryInterface $decoratedFactory,
+        FeedPreprocessorEntryReader $feedPreprocessorReader
+    ) {
         $this->productMockFactory = new ProductMockFactory();
         $this->variantMockFactory = new ProductVariantMockFactory();
         $this->feedPreprocessorEntryMockFactory = new FeedPreprocessorEntryMockFactory();
         $this->exportProductMockFactory = new ExportProductMockFactory();
+        $this->salesChannelProductMockFactory = new SalesChannelProductMockFactory();
+        $this->decoratedFactory = $decoratedFactory;
+        $this->feedPreprocessorReader = $feedPreprocessorReader;
+        $this->beConstructedWith($decoratedFactory,  new FieldsProvider(new \ArrayIterator()), $feedPreprocessorReader, $this->cachedFields);
     }
 
-    public function it_should_create_entities_for_variants_that_should_be_visible(
-        FactoryInterface $decoratedFactory,
-        FeedPreprocessorEntryReader $feedPreprocessorReader
-    ): void {
+    public function it_should_create_entities_for_variants_that_should_be_visible(): void
+    {
         // Given
         $productEntity = $this->productMockFactory->create();
         $variantsData = [
@@ -59,27 +70,33 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
             'SW100.18' => ['productNumber' => 'SW100.18', 'size' => 'L', 'color' => 'green', 'material' => 'linen'],
         ];
         $variants = array_map(fn (array $variantData) => $this->variantMockFactory->create($productEntity, $variantData), $variantsData);
-        $expectedVariants = [
-            $this->exportProductMockFactory->create($variants['SW100.1'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.1']->getProductNumber(), $variantsData)]),
-            $this->exportProductMockFactory->create($variants['SW100.5'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.5']->getProductNumber(), $variantsData)]),
-            $this->exportProductMockFactory->create($variants['SW100.7'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.7']->getProductNumber(), $variantsData)]),
-            $this->exportProductMockFactory->create($variants['SW100.10'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.10']->getProductNumber(), $variantsData)]),
-            $this->exportProductMockFactory->create($variants['SW100.13'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.13']->getProductNumber(), $variantsData)]),
-            $this->exportProductMockFactory->create($variants['SW100.16'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.16']->getProductNumber(), $variantsData)]),
+        $filterAttributes = [
+            'SW100.1' => 'size=S|size=M|size=L|color=red|material=cotton',
+            'SW100.5' => 'size=S|size=M|size=L|color=blue|material=cotton',
+            'SW100.7' => 'size=S|size=M|size=L|color=green|material=cotton',
+            'SW100.10' => 'size=S|size=M|size=L|color=red|material=linen',
+            'SW100.13' => 'size=S|size=M|size=L|color=blue|material=linen',
+            'SW100.16' => 'size=S|size=M|size=L|color=green|material=linen',
         ];
-        $productEntity->setChildren(new ProductCollection(array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array => $carriedVariants + [$product->getId() => $product], [])));
+        $expectedVariants = [
+            $this->exportProductMockFactory->create($variants['SW100.1'], ['filterAttributes' => $filterAttributes['SW100.1']]),
+            $this->exportProductMockFactory->create($variants['SW100.5'], ['filterAttributes' => $filterAttributes['SW100.5']]),
+            $this->exportProductMockFactory->create($variants['SW100.7'], ['filterAttributes' => $filterAttributes['SW100.7']]),
+            $this->exportProductMockFactory->create($variants['SW100.10'], ['filterAttributes' => $filterAttributes['SW100.10']]),
+            $this->exportProductMockFactory->create($variants['SW100.13'], ['filterAttributes' => $filterAttributes['SW100.13']]),
+            $this->exportProductMockFactory->create($variants['SW100.16'], ['filterAttributes' => $filterAttributes['SW100.16']]),
+        ];
+        $productEntity->setChildren(new ProductCollection(array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array => $carriedVariants + [$product->getId() => $this->salesChannelProductMockFactory->create($product)], [])));
 
         // Expect
-        $feedPreprocessorReader->read($productEntity)->willReturn($this->getFeedPreprocessorEntries([
-            $variants['SW100.1'],
-            $variants['SW100.5'],
-            $variants['SW100.7'],
-            $variants['SW100.10'],
-            $variants['SW100.13'],
-            $variants['SW100.16'],
-        ], $variantsData));
-        $decoratedFactory->createEntities($productEntity, ExportProductEntity::class)->willReturn(new \ArrayIterator(array_map(fn(ProductEntity $variant) => $this->exportProductMockFactory->create($variant), $variants)));
-        $this->beConstructedWith($decoratedFactory, $feedPreprocessorReader);
+        $this->feedPreprocessorReader->read($productEntity->getProductNumber())->willReturn($this->getFeedPreprocessorEntries($productEntity, [
+            $variantsData['SW100.1'] + ['filterAttributes' => $filterAttributes['SW100.1']],
+            $variantsData['SW100.5'] + ['filterAttributes' => $filterAttributes['SW100.5']],
+            $variantsData['SW100.7'] + ['filterAttributes' => $filterAttributes['SW100.7']],
+            $variantsData['SW100.10'] + ['filterAttributes' => $filterAttributes['SW100.10']],
+            $variantsData['SW100.13'] + ['filterAttributes' => $filterAttributes['SW100.13']],
+            $variantsData['SW100.16'] + ['filterAttributes' => $filterAttributes['SW100.16']],
+        ]));
 
         // When
         $exportedProducts = iterator_to_array($this->createEntities($productEntity)->getWrappedObject());
@@ -95,19 +112,68 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
      * @var ProductEntity[] $expectedVariants
      * @return FeedPreprocessorEntry[]
      */
-    private function getFeedPreprocessorEntries(array $expectedVariants, array $variantsData): array
+    private function getFeedPreprocessorEntries(ProductEntity $parent, array $variantsData): array
     {
         return array_reduce(
-            $expectedVariants,
-            fn(array $acc, ProductEntity $variant): array => $acc + [$variant->getProductNumber() => $this->feedPreprocessorEntryMockFactory->create($variant, ['filterAttributes' => $this->getFilterAttributes($variant->getProductNumber(), $variantsData)])],
+            $variantsData,
+            fn(array $acc, array $variantData): array => $acc + [$variantData['productNumber'] => $this->feedPreprocessorEntryMockFactory->create($this->variantMockFactory->create($parent, $variantData), ['filterAttributes' => $variantData['filterAttributes']])],
             []
         );
     }
 
-    private function getFilterAttributes(string $variantProductNumber, array $variantsData): string
+    public function it_should_create_entities_with_proper_custom_fields_for_each_display_group()
     {
-        $variantData = $variantsData[$variantProductNumber];
+        // Given
+        $productEntity = $this->productMockFactory->create();
+        $productEntity->setConfiguratorGroupConfig(ProductMockFactory::getGroupConfigurationConfig([
+            [md5('size'), 'true'],
+            [md5('color'), 'false'],
+            [md5('material'), 'false']
+        ]));
+        $customFieldsData = [
+            'SW100.1' => ['shape' => 'triangle', 'pattern' => 'stripes'],
+            'SW100.2' => ['shape' => 'triangle', 'pattern' => 'dots'],
+            'SW100.3' => ['shape' => 'square', 'pattern' => 'dots'],
+            'SW100.4' => ['shape' => 'triangle', 'pattern' => 'patterned'],
+            'SW100.5' => ['shape' => 'rectangle', 'pattern' => 'dots'],
+            'SW100.6' => ['shape' => 'rectangle', 'pattern' => 'stripes'],
+            'SW100.7' => ['shape' => 'rectangle', 'pattern' => 'dots'],
+            'SW100.8' => ['shape' => 'circle', 'pattern' => 'stripes'],
+        ];
+        $customFieldsValues = [
+            'SW100.1' => '|shape=triangle|pattern=stripes|',
+            'SW100.2' => '|shape=triangle|pattern=dots|',
+            'SW100.3' => '|shape=square|pattern=dots|',
+            'SW100.4' => '|shape=triangle|pattern=patterned|',
+            'SW100.5' => '|shape=rectangle|pattern=dots|',
+            'SW100.6' => '|shape=rectangle|pattern=stripes|',
+            'SW100.7' => '|shape=rectangle|pattern=dots|',
+            'SW100.8' => '|shape=circle|pattern=stripes|',
+        ];
+        $variants = [
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'green', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.1']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'green', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.2']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.3', 'size' => 'S', 'color' => 'green', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.3']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.4', 'size' => 'M', 'color' => 'green', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.4']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.5', 'size' => 'S', 'color' => 'red', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.5']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.6', 'size' => 'M', 'color' => 'red', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.6']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.7', 'size' => 'S', 'color' => 'red', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.7']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.8', 'size' => 'M', 'color' => 'red', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.8']]),
+        ];
+        $productEntity->setChildren(new ProductCollection(array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array => $carriedVariants + [$product->getId() => $product], [])));
 
-        return sprintf('size=S|size=M|size=L|color=%s|material=%s', $variantData['color'], $variantData['material']);
+        // Expect
+//        $this->feedPreprocessorReader->read($productEntity->getProductNumber())->willReturn($this->getFeedPreprocessorEntries([
+//            $variants['SW100.1'],
+//            $variants['SW100.5'],
+//            $variants['SW100.7'],
+//            $variants['SW100.10'],
+//            $variants['SW100.13'],
+//            $variants['SW100.16'],
+//        ], $variantsData));
+
+        $entities = iterator_to_array($this->createEntities($productEntity)->getWrappedObject());
+
     }
+
 }

--- a/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
+++ b/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Omikron\FactFinder\Shopware6\Export\Data\Factory;
+
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryReader;
+use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
+use Omikron\FactFinder\Shopware6\Export\Data\Factory\FactoryInterface;
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Omikron\FactFinder\Shopware6\TestUtil\FeedPreprocessorEntryMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\ExportProductMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\ProductMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\ProductVariantMockFactory;
+use PhpSpec\ObjectBehavior;
+use PHPUnit\Framework\Assert;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductEntity;
+
+class PreprocessedProductEntityFactorySpec extends ObjectBehavior
+{
+    private ProductMockFactory $productMockFactory;
+    private ProductVariantMockFactory $variantMockFactory;
+    private FeedPreprocessorEntryMockFactory $feedPreprocessorEntryMockFactory;
+    private ExportProductMockFactory $exportProductMockFactory;
+
+    function let()
+    {
+        $this->productMockFactory = new ProductMockFactory();
+        $this->variantMockFactory = new ProductVariantMockFactory();
+        $this->feedPreprocessorEntryMockFactory = new FeedPreprocessorEntryMockFactory();
+        $this->exportProductMockFactory = new ExportProductMockFactory();
+    }
+
+    public function it_should_create_entities_for_variants_that_should_be_visible(
+        FactoryInterface $decoratedFactory,
+        FeedPreprocessorEntryReader $feedPreprocessorReader
+    ): void {
+        // Given
+        $productEntity = $this->productMockFactory->create();
+        $variantsData = [
+            'SW100.1' => ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'red', 'material' => 'cotton'],
+            'SW100.2' => ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'red', 'material' => 'cotton'],
+            'SW100.3' => ['productNumber' => 'SW100.3', 'size' => 'L', 'color' => 'red', 'material' => 'cotton'],
+            'SW100.4' => ['productNumber' => 'SW100.4', 'size' => 'S', 'color' => 'blue', 'material' => 'cotton'],
+            'SW100.5' => ['productNumber' => 'SW100.5', 'size' => 'M', 'color' => 'blue', 'material' => 'cotton'],
+            'SW100.6' => ['productNumber' => 'SW100.6', 'size' => 'L', 'color' => 'blue', 'material' => 'cotton'],
+            'SW100.7' => ['productNumber' => 'SW100.7', 'size' => 'S', 'color' => 'green', 'material' => 'cotton'],
+            'SW100.8' => ['productNumber' => 'SW100.8', 'size' => 'M', 'color' => 'green', 'material' => 'cotton'],
+            'SW100.9' => ['productNumber' => 'SW100.9', 'size' => 'L', 'color' => 'green', 'material' => 'cotton'],
+            'SW100.10' => ['productNumber' => 'SW100.10', 'size' => 'S', 'color' => 'red', 'material' => 'linen'],
+            'SW100.11' => ['productNumber' => 'SW100.11', 'size' => 'M', 'color' => 'red', 'material' => 'linen'],
+            'SW100.12' => ['productNumber' => 'SW100.12', 'size' => 'L', 'color' => 'red', 'material' => 'linen'],
+            'SW100.13' => ['productNumber' => 'SW100.13', 'size' => 'S', 'color' => 'blue', 'material' => 'linen'],
+            'SW100.14' => ['productNumber' => 'SW100.14', 'size' => 'M', 'color' => 'blue', 'material' => 'linen'],
+            'SW100.15' => ['productNumber' => 'SW100.15', 'size' => 'L', 'color' => 'blue', 'material' => 'linen'],
+            'SW100.16' => ['productNumber' => 'SW100.16', 'size' => 'S', 'color' => 'green', 'material' => 'linen'],
+            'SW100.17' => ['productNumber' => 'SW100.17', 'size' => 'M', 'color' => 'green', 'material' => 'linen'],
+            'SW100.18' => ['productNumber' => 'SW100.18', 'size' => 'L', 'color' => 'green', 'material' => 'linen'],
+        ];
+        $variants = array_map(fn (array $variantData) => $this->variantMockFactory->create($productEntity, $variantData), $variantsData);
+        $expectedVariants = [
+            $this->exportProductMockFactory->create($variants['SW100.1'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.1']->getProductNumber(), $variantsData)]),
+            $this->exportProductMockFactory->create($variants['SW100.5'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.5']->getProductNumber(), $variantsData)]),
+            $this->exportProductMockFactory->create($variants['SW100.7'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.7']->getProductNumber(), $variantsData)]),
+            $this->exportProductMockFactory->create($variants['SW100.10'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.10']->getProductNumber(), $variantsData)]),
+            $this->exportProductMockFactory->create($variants['SW100.13'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.13']->getProductNumber(), $variantsData)]),
+            $this->exportProductMockFactory->create($variants['SW100.16'], ['filterAttributes' => $this->getFilterAttributes($variants['SW100.16']->getProductNumber(), $variantsData)]),
+        ];
+        $productEntity->setChildren(new ProductCollection(array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array => $carriedVariants + [$product->getId() => $product], [])));
+
+        // Expect
+        $feedPreprocessorReader->read($productEntity)->willReturn($this->getFeedPreprocessorEntries([
+            $variants['SW100.1'],
+            $variants['SW100.5'],
+            $variants['SW100.7'],
+            $variants['SW100.10'],
+            $variants['SW100.13'],
+            $variants['SW100.16'],
+        ], $variantsData));
+        $decoratedFactory->createEntities($productEntity, ExportProductEntity::class)->willReturn(new \ArrayIterator(array_map(fn(ProductEntity $variant) => $this->exportProductMockFactory->create($variant), $variants)));
+        $this->beConstructedWith($decoratedFactory, $feedPreprocessorReader);
+
+        // When
+        $exportedProducts = iterator_to_array($this->createEntities($productEntity)->getWrappedObject());
+
+        // Then
+        Assert::assertEquals(
+            array_values(array_map(fn(ExportProductEntity $variant) => $variant->toArray(), $expectedVariants)),
+            array_values(array_map(fn (ExportProductEntity $product) => $product->toArray(), $exportedProducts))
+        );
+    }
+
+    /**
+     * @var ProductEntity[] $expectedVariants
+     * @return FeedPreprocessorEntry[]
+     */
+    private function getFeedPreprocessorEntries(array $expectedVariants, array $variantsData): array
+    {
+        return array_reduce(
+            $expectedVariants,
+            fn(array $acc, ProductEntity $variant): array => $acc + [$variant->getProductNumber() => $this->feedPreprocessorEntryMockFactory->create($variant, ['filterAttributes' => $this->getFilterAttributes($variant->getProductNumber(), $variantsData)])],
+            []
+        );
+    }
+
+    private function getFilterAttributes(string $variantProductNumber, array $variantsData): string
+    {
+        $variantData = $variantsData[$variantProductNumber];
+
+        return sprintf('size=S|size=M|size=L|color=%s|material=%s', $variantData['color'], $variantData['material']);
+    }
+}

--- a/src/Command/DataExportCommand.php
+++ b/src/Command/DataExportCommand.php
@@ -155,13 +155,8 @@ class DataExportCommand extends Command implements ContainerAwareInterface
         $feedColumns      = $this->getFeedColumns($exportType, $entityFQN);
 
         $needFile = $saveFile || $uploadFeed;
-        $out   = $needFile ? new CsvFile($this->createFile($exportType, $context->getSalesChannelId())) : new ConsoleOutput($output);
-        $start = microtime(true);
+        $out      = $needFile ? new CsvFile($this->createFile($exportType, $context->getSalesChannelId())) : new ConsoleOutput($output);
         $feedService->generate($out, $feedColumns);
-
-        $end = microtime(true);
-        $executionTime = ($end - $start);
-        $output->writeln($executionTime);
 
         if ($uploadFeed) {
             $this->uploadService->upload($this->file);

--- a/src/Command/DataExportCommand.php
+++ b/src/Command/DataExportCommand.php
@@ -156,7 +156,12 @@ class DataExportCommand extends Command implements ContainerAwareInterface
 
         $needFile = $saveFile || $uploadFeed;
         $out   = $needFile ? new CsvFile($this->createFile($exportType, $context->getSalesChannelId())) : new ConsoleOutput($output);
+        $start = microtime(true);
         $feedService->generate($out, $feedColumns);
+
+        $end = microtime(true);
+        $executionTime = ($end - $start);
+        $output->writeln($executionTime);
 
         if ($uploadFeed) {
             $this->uploadService->upload($this->file);

--- a/src/Command/DataExportCommand.php
+++ b/src/Command/DataExportCommand.php
@@ -155,8 +155,8 @@ class DataExportCommand extends Command implements ContainerAwareInterface
         $feedColumns      = $this->getFeedColumns($exportType, $entityFQN);
 
         $needFile = $saveFile || $uploadFeed;
-        $output   = $needFile ? new CsvFile($this->createFile($exportType, $context->getSalesChannelId())) : new ConsoleOutput($output);
-        $feedService->generate($output, $feedColumns);
+        $out   = $needFile ? new CsvFile($this->createFile($exportType, $context->getSalesChannelId())) : new ConsoleOutput($output);
+        $feedService->generate($out, $feedColumns);
 
         if ($uploadFeed) {
             $this->uploadService->upload($this->file);

--- a/src/Command/RunPreprocessorCommand.php
+++ b/src/Command/RunPreprocessorCommand.php
@@ -48,7 +48,7 @@ class RunPreprocessorCommand extends Command
 
     protected function configure()
     {
-        $this->setName('factfinder:data:preprocess');
+        $this->setName('factfinder:data:pre-process');
         $this->setDescription('Run the Feed preprocessor');
         $this->addArgument(self::SALES_CHANNEL_LANGUAGE_ARGUMENT, InputArgument::OPTIONAL, 'ID of the sales channel language');
         $this->addArgument(self::SALES_CHANNEL_ARGUMENT, InputArgument::OPTIONAL, 'ID of the sales channel');

--- a/src/Command/RunPreprocessorCommand.php
+++ b/src/Command/RunPreprocessorCommand.php
@@ -73,17 +73,12 @@ class RunPreprocessorCommand extends Command
         $salesChannelContext = $this->channelService->getSalesChannelContext($salesChannel, $language->getId());
         $context = $salesChannelContext->getContext();
 
-        $start = microtime(true);
         /** @var ProductEntity $product */
 
         foreach ($this->exportProducts->getByContext($salesChannelContext) as $product) {
             $this->entryPersister->deleteAllProductEntries($product->getProductNumber(),$context);
             $this->entryPersister->insertProductEntries($this->feedPreprocessor->createEntries($product, $context), $context);
         };
-
-        $end = microtime(true);
-        $execution_time = ($end - $start);
-        $output->writeln($execution_time);
 
         return 0;
     }

--- a/src/Command/RunPreprocessorCommand.php
+++ b/src/Command/RunPreprocessorCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Command;
@@ -19,12 +20,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 
 class RunPreprocessorCommand extends Command
 {
-    public const SALES_CHANNEL_ARGUMENT = 'sales_channel';
+    public const SALES_CHANNEL_ARGUMENT          = 'sales_channel';
     public const SALES_CHANNEL_LANGUAGE_ARGUMENT = 'language';
 
     private FeedPreprocessor $feedPreprocessor;
@@ -35,12 +35,12 @@ class RunPreprocessorCommand extends Command
     private EntityRepositoryInterface $channelRepository;
 
     public function __construct(
-        FeedPreprocessor               $feedPreprocessor,
+        FeedPreprocessor $feedPreprocessor,
         FeedPreprocessorEntryPersister $feedPreprocessorEntryPersister,
-        SalesChannelService            $salesChannelService,
-        ExportProducts                 $exportProducts,
-        EntityRepositoryInterface      $languageRepository,
-        EntityRepositoryInterface      $channelRepository
+        SalesChannelService $salesChannelService,
+        ExportProducts $exportProducts,
+        EntityRepositoryInterface $languageRepository,
+        EntityRepositoryInterface $channelRepository
     ) {
         parent::__construct();
         $this->feedPreprocessor   = $feedPreprocessor;
@@ -51,7 +51,7 @@ class RunPreprocessorCommand extends Command
         $this->channelRepository  = $channelRepository;
     }
 
-    protected function configure()
+    public function configure(): void
     {
         $this->setName('factfinder:data:pre-process');
         $this->setDescription('Run the Feed preprocessor');
@@ -62,7 +62,7 @@ class RunPreprocessorCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->isInteractive()) {
-            $helper = $this->getHelper('question');
+            $helper           = $this->getHelper('question');
             $salesChannel     = $this->getSalesChannel($helper->ask($input, $output, new Question('ID of the sales channel (leave empty if no value): ')));
             $language         = $this->getLanguage($helper->ask($input, $output, new Question('ID of the sales channel language (leave empty if no value): ')));
         } else {
@@ -71,14 +71,13 @@ class RunPreprocessorCommand extends Command
         }
 
         $salesChannelContext = $this->channelService->getSalesChannelContext($salesChannel, $language->getId());
-        $context = $salesChannelContext->getContext();
+        $context             = $salesChannelContext->getContext();
 
         /** @var ProductEntity $product */
-
         foreach ($this->exportProducts->getByContext($salesChannelContext) as $product) {
-            $this->entryPersister->deleteAllProductEntries($product->getProductNumber(),$context);
+            $this->entryPersister->deleteAllProductEntries($product->getProductNumber(), $context);
             $this->entryPersister->insertProductEntries($this->feedPreprocessor->createEntries($product, $context), $context);
-        };
+        }
 
         return 0;
     }

--- a/src/Command/RunPreprocessorCommand.php
+++ b/src/Command/RunPreprocessorCommand.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Command;
+
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessor;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryPersister;
+use Omikron\FactFinder\Shopware6\Export\ExportProducts;
+use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RunPreprocessorCommand extends Command
+{
+    public const SALES_CHANNEL_ARGUMENT = 'sales_channel';
+    public const SALES_CHANNEL_LANGUAGE_ARGUMENT = 'language';
+
+    private FeedPreprocessor $feedPreprocessor;
+    private FeedPreprocessorEntryPersister $entryPersister;
+    private ExportProducts $exportProducts;
+    private SalesChannelService $channelService;
+    private EntityRepositoryInterface $languageRepository;
+
+    public function __construct(
+        FeedPreprocessor               $feedPreprocessor,
+        FeedPreprocessorEntryPersister $feedPreprocessorEntryPersister,
+        SalesChannelService            $salesChannelService,
+        ExportProducts                 $exportProducts,
+        EntityRepositoryInterface      $languageRepository
+    ) {
+        parent::__construct();
+        $this->feedPreprocessor   = $feedPreprocessor;
+        $this->entryPersister     = $feedPreprocessorEntryPersister;
+        $this->channelService     = $salesChannelService;
+        $this->exportProducts     = $exportProducts;
+        $this->languageRepository = $languageRepository;
+    }
+
+    protected function configure()
+    {
+        $this->setName('factfinder:preprocessor:run');
+        $this->setDescription('Run the Feed preprocessor');
+        $this->addArgument(self::SALES_CHANNEL_LANGUAGE_ARGUMENT, InputArgument::OPTIONAL, 'ID of the sales channel language');
+        $this->addArgument(self::SALES_CHANNEL_ARGUMENT, InputArgument::OPTIONAL, 'ID of the sales channel');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $salesChannel = $this->getSalesChannel($input->getArgument(self::SALES_CHANNEL_ARGUMENT));
+        $language     = $this->getLanguage($input->getArgument(self::SALES_CHANNEL_LANGUAGE_ARGUMENT));
+        $context      = $this->channelService->getSalesChannelContext($salesChannel, $language->getId());
+
+        /** @var ProductEntity $product */
+        foreach ($this->exportProducts->getByContext($context) as $product) {
+            $this->entryPersister->deleteAllProductEntries($product->getProductNumber(), $context->getContext());
+            $this->feedPreprocessor->setContext($context->getContext());
+            $this->feedPreprocessor->createEntries($product);
+        };
+
+        return 0;
+    }
+
+    private function getLanguage(string $id = null): LanguageEntity
+    {
+        return $this->languageRepository->search(
+            new Criteria([$id ?: Defaults::LANGUAGE_SYSTEM]),
+            new Context(new SystemSource())
+        )->first();
+    }
+
+    private function getSalesChannel(string $id = null): ?SalesChannelEntity
+    {
+        return !is_null($id)
+            ? $this->channelRepository->search(new Criteria([$id]), new Context(new SystemSource()))->first()
+            : null;
+    }
+}

--- a/src/Command/RunPreprocessorCommand.php
+++ b/src/Command/RunPreprocessorCommand.php
@@ -22,6 +22,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ElseExpression)
+ */
 class RunPreprocessorCommand extends Command
 {
     public const SALES_CHANNEL_ARGUMENT          = 'sales_channel';
@@ -36,7 +40,7 @@ class RunPreprocessorCommand extends Command
 
     public function __construct(
         FeedPreprocessor $feedPreprocessor,
-        FeedPreprocessorEntryPersister $feedPreprocessorEntryPersister,
+        FeedPreprocessorEntryPersister $entryPersister,
         SalesChannelService $salesChannelService,
         ExportProducts $exportProducts,
         EntityRepositoryInterface $languageRepository,
@@ -44,7 +48,7 @@ class RunPreprocessorCommand extends Command
     ) {
         parent::__construct();
         $this->feedPreprocessor   = $feedPreprocessor;
-        $this->entryPersister     = $feedPreprocessorEntryPersister;
+        $this->entryPersister     = $entryPersister;
         $this->channelService     = $salesChannelService;
         $this->exportProducts     = $exportProducts;
         $this->languageRepository = $languageRepository;

--- a/src/Config/ExportSettings.php
+++ b/src/Config/ExportSettings.php
@@ -21,6 +21,11 @@ class ExportSettings extends BaseConfig
         return (bool) $this->config('currencyPriceExport');
     }
 
+    public function isExportCacheEnable(): bool
+    {
+        return (bool) $this->config('enableExportCache');
+    }
+
     private function toArray(?array $value): array
     {
         return (array) $value;

--- a/src/DataAbstractionLayer/FeedPreprocessor.php
+++ b/src/DataAbstractionLayer/FeedPreprocessor.php
@@ -58,7 +58,9 @@ class FeedPreprocessor
 
             //loop over the options to collect those, that should be aggregated in exported products
             foreach ($child->getOptions() as $option) {
-                if ($shouldGroupBeVisible($option->getGroupId()) || $visibleGroupIds === []) {
+                $hasMainVariant = (bool) $product->getMainVariantId();
+
+                if (($shouldGroupBeVisible($option->getGroupId()) || $visibleGroupIds === []) && !$hasMainVariant) {
                     /**
                      * if a given option should be presented on storefront, we store its id
                      * This is used later to collect only unique combination of product variants
@@ -81,6 +83,7 @@ class FeedPreprocessor
 
             //store variant data to prevent iterating them again later
             $entries[$variationKey] = $this->formEntry($product, $context, $variationKey);
+            $entries[$variationKey]['productNumber'] = $child->getProductNumber();
 
             $filtersFromNotVisibleVariants[$variationKey] = implode('|', flatMap(fn(
                 array $groupOptions) => array_values($groupOptions), array_values($notVisibleGroups)));

--- a/src/DataAbstractionLayer/FeedPreprocessor.php
+++ b/src/DataAbstractionLayer/FeedPreprocessor.php
@@ -22,27 +22,27 @@ class FeedPreprocessor
     private ExportCustomFields $customFields;
 
     public function __construct(
-        PropertyFormatter        $propertyFormatter,
+        PropertyFormatter $propertyFormatter,
         EventDispatcherInterface $eventDispatcher,
-        ExportCustomFields       $customFields
+        ExportCustomFields $customFields
     ) {
         $this->propertyFormatter = $propertyFormatter;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->customFields = $customFields;
+        $this->eventDispatcher   = $eventDispatcher;
+        $this->customFields      = $customFields;
     }
 
     public function createEntries(ProductEntity $product, Context $context): array
     {
         $filtersFromNotVisibleVariants = [];
-        $filtersFromVisibleVariants = [];
-        $notVisibleGroups = [];
-        $entries = [];
-        $customFields = [];
+        $filtersFromVisibleVariants    = [];
+        $notVisibleGroups              = [];
+        $entries                       = [];
+        $customFields                  = [];
 
         if ($product->getChildCount() === 0) {
             $customFields = explode('|', $this->customFields->getValue($product));
-            $entry = $this->formEntry($product, $context, implode('|', array_unique($customFields)));
-            $event = new FeedPreprocessorEntryBeforeCreate($entry, $context);
+            $entry        = $this->formEntry($product, $context, implode('|', array_unique($customFields)));
+            $event        = new FeedPreprocessorEntryBeforeCreate($entry, $context);
             $this->eventDispatcher->dispatch($event);
 
             return [$event->getEntry()];
@@ -53,15 +53,15 @@ class FeedPreprocessor
         /** @var \Shopware\Core\Content\Product\ProductEntity $child */
         foreach ($product->getChildren() as $child) {
             //fetch storefront presentation config for each variant
-            $shouldGroupBeVisible = fn(string $groupId): bool => in_array($groupId, $visibleGroupIds);
-            $variationKeyParts = [];
+            $shouldGroupBeVisible = fn (string $groupId): bool => in_array($groupId, $visibleGroupIds);
+            $variationKeyParts    = [];
 
             //loop over the options to collect those, that should be aggregated in exported products
             foreach ($child->getOptions() as $option) {
                 $hasMainVariant = (bool) $product->getMainVariantId();
 
                 if (($shouldGroupBeVisible($option->getGroupId()) || $visibleGroupIds === []) && !$hasMainVariant) {
-                    /**
+                    /*
                      * if a given option should be presented on storefront, we store its id
                      * This is used later to collect only unique combination of product variants
                      */
@@ -82,13 +82,13 @@ class FeedPreprocessor
             }
 
             //store variant data to prevent iterating them again later
-            $entries[$variationKey] = $this->formEntry($product, $context, $variationKey);
+            $entries[$variationKey]                  = $this->formEntry($product, $context, $variationKey);
             $entries[$variationKey]['productNumber'] = $child->getProductNumber();
 
-            $filtersFromNotVisibleVariants[$variationKey] = implode('|', flatMap(fn(
+            $filtersFromNotVisibleVariants[$variationKey] = implode('|', flatMap(fn (
                 array $groupOptions) => array_values($groupOptions), array_values($notVisibleGroups)));
 
-            $filtersFromVisibleVariants[$variationKey] = implode('|', array_filter($child->getOptions()->map(fn(
+            $filtersFromVisibleVariants[$variationKey] = implode('|', array_filter($child->getOptions()->map(fn (
                 PropertyGroupOptionEntity $option): string => in_array($option->getGroupId(), $visibleGroupIds) ? call_user_func($this->propertyFormatter, $option) : '')));
         }
 
@@ -107,16 +107,16 @@ class FeedPreprocessor
     private function extractVisibleGroupIds(ProductEntity $product): array
     {
         $configuratorGroupConfig = $product->getConfiguratorGroupConfig();
-        $hasMainVariant = (bool) $product->getMainVariantId();
+        $hasMainVariant          = (bool) $product->getMainVariantId();
 
         if (!$configuratorGroupConfig) {
             return [];
         }
         return array_reduce(
             array_filter($product->getConfiguratorGroupConfig(),
-                fn(
+                fn (
                     array $groupConfig): bool => !$hasMainVariant && (bool) safeGetByName($groupConfig, 'expressionForListings')),
-            fn(
+            fn (
                 array $result,
                 array $groupConfig): array => array_merge($result, [safeGetByName($groupConfig, 'id')]), []
         );
@@ -130,13 +130,13 @@ class FeedPreprocessor
         ?array $filterAttributes = null
     ): array {
         return [
-            'id' => Uuid::randomHex(),
-            'productNumber' => $product->getProductNumber(),
-            'variationKey' => $variationKey,
+            'id'                  => Uuid::randomHex(),
+            'productNumber'       => $product->getProductNumber(),
+            'variationKey'        => $variationKey,
             'parentProductNumber' => $product->getProductNumber(),
-            'languageId' => Uuid::fromHexToBytes($context->getLanguageId()),
-            'filterAttributes' => $filterAttributes ? "|$filterAttributes|" : '',
-            'customFields' => $customFields ?  "|$customFields|" : ''
+            'languageId'          => Uuid::fromHexToBytes($context->getLanguageId()),
+            'filterAttributes'    => $filterAttributes ? "|$filterAttributes|" : '',
+            'customFields'        => $customFields ? "|$customFields|" : '',
         ];
     }
 }

--- a/src/DataAbstractionLayer/FeedPreprocessor.php
+++ b/src/DataAbstractionLayer/FeedPreprocessor.php
@@ -90,12 +90,23 @@ class FeedPreprocessor
         $entries = array_map(function (array $entry) use ($filtersFromVisibleVariants, $filtersFromNotVisibleVariants, $customFields) {
             $variationKey = $entry['variationKey'];
             $entry['filterAttributes'] = implode('|', [$filtersFromNotVisibleVariants[$variationKey], $filtersFromVisibleVariants[$variationKey]]);
-            $entry['customFields'] = sprintf('|%s|', implode('|', array_unique($customFields[$variationKey])));
+            $entry['customFields'] = $this->getCustomFields($customFields, $variationKey);
 
             return $entry;
         }, $entries);
 
         return $entries;
+    }
+
+    private function getCustomFields(array $customFields, string $variationKey): string
+    {
+        $customFields = sprintf('|%s|', implode('|', array_unique($customFields[$variationKey])));
+
+        if ($customFields === '||') {
+            return '';
+        }
+
+        return $customFields;
     }
 
     private function extractVisibleGroupIds(ProductEntity $product): array

--- a/src/DataAbstractionLayer/FeedPreprocessor.php
+++ b/src/DataAbstractionLayer/FeedPreprocessor.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
+
+use Omikron\FactFinder\Shopware6\Events\FeedPreprocessorEntryBeforeCreate;
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Omikron\FactFinder\Shopware6\Export\Field\CustomFields as ExportCustomFields;
+use Omikron\FactFinder\Shopware6\Export\PropertyFormatter;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function Omikron\FactFinder\Shopware6\Internal\Utils\flatMap;
+use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;
+
+class FeedPreprocessor
+{
+    private ?Context $context = null;
+    private PropertyFormatter $propertyFormatter;
+    private EventDispatcherInterface $eventDispatcher;
+    private ExportCustomFields $customFields;
+
+    public function __construct(
+        PropertyFormatter        $propertyFormatter,
+        EventDispatcherInterface $eventDispatcher,
+        ExportCustomFields       $customFields
+    )
+    {
+        $this->propertyFormatter = $propertyFormatter;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->customFields = $customFields;
+    }
+
+    public function setContext(?Context $context): void
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * @return FeedPreprocessorEntry[]
+     */
+    public function createEntries(ProductEntity $product): array
+    {
+        $filtersFromNotVisibleVariants = [];
+        $filtersFromVisibleVariants = [];
+        $notVisibleGroups = [];
+        $entries = [];
+        $customFields = [];
+
+        /** @var \Shopware\Core\Content\Product\ProductEntity $child */
+        foreach ($product->getChildren() as $child) {
+            //fetch storefront presentation config for each variant
+            $visibleGroupIds = $this->extractVisibleGroupIds($product);
+            $shouldGroupBeVisible = fn(string $groupId): bool => in_array($groupId, $visibleGroupIds);
+            $variationKeyParts = [];
+
+            //loop over the options to collect those, that should be aggregated in exported products
+            foreach ($child->getOptions() as $option) {
+                if ($shouldGroupBeVisible($option->getGroupId())) {
+                    /**
+                     * if a given option should be presented on storefront, we store its id
+                     * This is used later to collect only unique combination of product variants
+                     */
+                    $variationKeyParts[] = $option->getId();
+                } else {
+                    //if not then we format the option to a "ready to be exported" expression
+                    $notVisibleGroups[$option->getGroupId()][$option->getId()] = call_user_func($this->propertyFormatter, $option);
+                }
+            }
+
+            //collect all variants that should be visible used variation key created in a loop before
+            $variationKey = implode('-', $variationKeyParts);
+
+            $childCustomFields = explode('|', trim($this->customFields->getValue($child), '|'));
+
+            foreach ($childCustomFields as $childCustomField) {
+                $customFields[$variationKey][] = $childCustomField;
+            }
+
+            //store variant data to prevent iterating them again later
+
+            $entries[$variationKey] = (new FeedPreprocessorEntry())
+                ->setId(Uuid::randomHex())
+                ->setProductNumber($child->getProductNumber())
+                ->setVariationKey($variationKey)
+                ->setParentProductNumber($product->getProductNumber())
+                ->setLanguageId($this->context->getLanguageId())
+                ->setAdditionalCache([]);
+
+            //collect all possible ready to be exported expressions from group that should not be visible
+            $filtersFromNotVisibleVariants[$variationKey] = implode('|', flatMap(fn(
+                array $groupOptions) => array_values($groupOptions), array_values($notVisibleGroups)));
+
+            $filtersFromVisibleVariants[$variationKey] = implode('|', array_filter($child->getOptions()->map(fn(
+                PropertyGroupOptionEntity $option): string => in_array($option->getGroupId(), $visibleGroupIds) ? call_user_func($this->propertyFormatter, $option) : '')));
+        }
+
+        array_walk($entries, function (FeedPreprocessorEntry $entry) use (
+            $filtersFromVisibleVariants,
+            $filtersFromNotVisibleVariants,
+            $customFields
+        ): void {
+            $variationKey = $entry->getVariationKey();
+            $gluedFilters = implode('|', [$filtersFromNotVisibleVariants[$variationKey], $filtersFromVisibleVariants[$variationKey]]);
+            $entry->setFilterAttributes($gluedFilters);
+            $entry->setCustomFields(sprintf('|%s|', implode('|', array_unique($customFields[$variationKey]))));
+
+            $this->eventDispatcher->dispatch(new FeedPreprocessorEntryBeforeCreate($entry, $this->context));
+        });
+
+        return $entries;
+    }
+
+    private function extractVisibleGroupIds(ProductEntity $product): array
+    {
+        $configuratorGroupConfig = $product->getConfiguratorGroupConfig();
+        if (!$configuratorGroupConfig) {
+            return [];
+        }
+        return array_reduce(
+            array_filter($product->getConfiguratorGroupConfig(),
+                fn(
+                    array $groupConfig): bool => (bool)safeGetByName($groupConfig, 'expressionForListings')),
+            fn(
+                array $result,
+                array $groupConfig): array => array_merge($result, [safeGetByName($groupConfig, 'id')]), []
+        );
+    }
+}

--- a/src/DataAbstractionLayer/FeedPreprocessor.php
+++ b/src/DataAbstractionLayer/FeedPreprocessor.php
@@ -48,7 +48,7 @@ class FeedPreprocessor
                 'variationKey' => '',
                 'parentProductNumber' => $product->getProductNumber(),
                 'languageId' => Uuid::fromHexToBytes($context->getLanguageId()),
-                'filterAttributes' => '||',
+                'filterAttributes' => '',
                 'customFields' => sprintf('|%s|', implode('|', array_unique($customFields))),
             ];
             $event = new FeedPreprocessorEntryBeforeCreate($entry, $context);
@@ -109,6 +109,7 @@ class FeedPreprocessor
         return array_map(function (array $entry) use ($filtersFromVisibleVariants, $filtersFromNotVisibleVariants, $customFields, $context) {
             $variationKey = $entry['variationKey'];
             $entry['filterAttributes'] = implode('|', [$filtersFromNotVisibleVariants[$variationKey], $filtersFromVisibleVariants[$variationKey]]);
+            $entry['filterAttributes'] = trim($entry['filterAttributes'], '|');
             $entry['customFields'] = sprintf('|%s|', implode('|', array_unique($customFields[$variationKey])));
             $event = new FeedPreprocessorEntryBeforeCreate($entry, $context);
             $this->eventDispatcher->dispatch($event);

--- a/src/DataAbstractionLayer/FeedPreprocessor.php
+++ b/src/DataAbstractionLayer/FeedPreprocessor.php
@@ -49,7 +49,7 @@ class FeedPreprocessor
 
             //loop over the options to collect those, that should be aggregated in exported products
             foreach ($child->getOptions() as $option) {
-                if ($shouldGroupBeVisible($option->getGroupId())) {
+                if ($shouldGroupBeVisible($option->getGroupId()) || $visibleGroupIds === []) {
                     /**
                      * if a given option should be presented on storefront, we store its id
                      * This is used later to collect only unique combination of product variants

--- a/src/DataAbstractionLayer/FeedPreprocessor.php
+++ b/src/DataAbstractionLayer/FeedPreprocessor.php
@@ -101,7 +101,7 @@ class FeedPreprocessor
             $variationKey = $entry['variationKey'];
             $filters = implode('|', array_filter([$noVisibleVariantsFilters[$variationKey], $visibleVariantsFilters[$variationKey]]));
             $entry['filterAttributes'] = $filters ? "|$filters|" : '';
-            $entry['customFields'] = array_filter($customFields[$variationKey]) ? '|' . implode('|', array_unique($customFields[$variationKey])) . '|' : '';
+            $entry['customFields'] = array_filter($customFields[$variationKey]) ? sprintf('|%s|', trim(implode('|', array_unique($customFields[$variationKey])), '|')) : '';
             $event = new FeedPreprocessorEntryBeforeCreate($entry, $context);
             $this->eventDispatcher->dispatch($event);
 

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
@@ -39,18 +39,6 @@ class FeedPreprocessorEntryPersister
      */
     public function insertProductEntries(array $entries, Context $context): void
     {
-        foreach ($entries as $entry) {
-            $entryData = [
-                'languageId'          => Uuid::fromHexToBytes($entry->getLanguageId()),
-                'productNumber'       => $entry->getProductNumber(),
-                'parentProductNumber' => $entry->getParentProductNumber(),
-                'variationKey'        => $entry->getVariationKey(),
-                'filterAttributes'    => $entry->getFilterAttributes(),
-                'customFields'        => $entry->getCustomFields(),
-                'additionalCache'     => $entry->getAdditionalCache()
-            ];
-
-            $this->entryRepository->create([$entryData], $context);
-        }
+        $this->entryRepository->create(array_values($entries), $context);
     }
 }

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
 
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 
 class FeedPreprocessorEntryPersister
 {
-    private EntityRepositoryInterface $entryRepository;
+    private EntityRepository $entryRepository;
 
-    public function __construct(EntityRepositoryInterface $entryRepository)
+    public function __construct(EntityRepository $entryRepository)
     {
         $this->entryRepository = $entryRepository;
     }

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
@@ -13,9 +13,9 @@ class FeedPreprocessorEntryPersister
 {
     private EntityRepositoryInterface $entryRepository;
 
-    public function __construct(EntityRepositoryInterface $feedPreprocessorEntryRepository)
+    public function __construct(EntityRepositoryInterface $entryRepository)
     {
-        $this->entryRepository = $feedPreprocessorEntryRepository;
+        $this->entryRepository = $entryRepository;
     }
 
     public function deleteAllProductEntries(string $productNumber, Context $context): void

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\Uuid\Uuid;
 
 class FeedPreprocessorEntryPersister
 {
@@ -23,7 +22,7 @@ class FeedPreprocessorEntryPersister
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
-        $ids = array_map(fn(
+        $ids = array_map(fn (
             string $id): array => ['id' => $id], $this->entryRepository->searchIds($criteria, $context)->getIds());
 
         $this->entryRepository->delete($ids, $context);

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
@@ -23,10 +23,6 @@ class FeedPreprocessorEntryPersister
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
-        $a = $this->entryRepository->search($criteria, $context)->getElements();
-
-        $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
         $ids = array_map(fn(
             string $id): array => ['id' => $id], $this->entryRepository->searchIds($criteria, $context)->getIds());
 

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
@@ -50,11 +50,7 @@ class FeedPreprocessorEntryPersister
                 'additionalCache'     => $entry->getAdditionalCache()
             ];
 
-            try {
-                $this->entryRepository->create([$entryData], $context);
-            } catch (\Throwable $e) {
-                //@todo implement me
-            }
+            $this->entryRepository->create([$entryData], $context);
         }
     }
 }

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class FeedPreprocessorEntryPersister
+{
+    private EntityRepositoryInterface $entryRepository;
+
+    public function __construct(EntityRepositoryInterface $feedPreprocessorEntryRepository)
+    {
+        $this->entryRepository = $feedPreprocessorEntryRepository;
+    }
+
+    public function deleteAllProductEntries(string $productNumber, Context $context): void
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
+        $a = $this->entryRepository->search($criteria, $context)->getElements();
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
+        $ids = array_map(fn(
+            string $id): array => ['id' => $id], $this->entryRepository->searchIds($criteria, $context)->getIds());
+
+        $this->entryRepository->delete($ids, $context);
+    }
+
+    /**
+     * @param array[FeedPreprocessorEntry] $entries
+     * @param Context $context
+     */
+    public function insertProductEntries(array $entries, Context $context): void
+    {
+        foreach ($entries as $entry) {
+            $entryData = [
+                'languageId'          => Uuid::fromHexToBytes($entry->getLanguageId()),
+                'productNumber'       => $entry->getProductNumber(),
+                'parentProductNumber' => $entry->getParentProductNumber(),
+                'variationKey'        => $entry->getVariationKey(),
+                'filterAttributes'    => $entry->getFilterAttributes(),
+                'customFields'        => $entry->getCustomFields(),
+                'additionalCache'     => $entry->getAdditionalCache()
+            ];
+
+            try {
+                $this->entryRepository->create([$entryData], $context);
+            } catch (\Throwable $e) {
+                //@todo implement me
+            }
+        }
+    }
+}

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
+
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+
+class FeedPreprocessorEntryReader
+{
+    private SalesChannelService $channelService;
+    private EntityRepositoryInterface $feedPreprocessorEntryRepository;
+
+    public function __construct(
+        SalesChannelService $channelService,
+        EntityRepositoryInterface $feedPreprocessorEntryRepository
+    ) {
+        $this->channelService = $channelService;
+        $this->feedPreprocessorEntryRepository = $feedPreprocessorEntryRepository;
+    }
+
+    /**
+     * @return FeedPreprocessorEntry[]
+     */
+    public function read(string $productNumber): array
+    {
+        $context = $this->channelService->getSalesChannelContext()->getContext();
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
+        $preprocessedFeeds = $this->feedPreprocessorEntryRepository->search($criteria, $context)->getElements();
+
+        return array_reduce($preprocessedFeeds, function (array $acc, FeedPreprocessorEntry $preprocessedFeed) {
+            $number = $preprocessedFeed->getProductNumber();
+
+            if ($number !== null) {
+                $acc[$number] = $preprocessedFeed;
+            }
+
+            return $acc;
+        }, []);
+    }
+}

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -20,12 +20,13 @@ class FeedPreprocessorEntryReader
         SalesChannelService $channelService,
         EntityRepositoryInterface $entryRepository
     ) {
-        $this->channelService                  = $channelService;
+        $this->channelService  = $channelService;
         $this->entryRepository = $entryRepository;
     }
 
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
+     *
      * @return FeedPreprocessorEntry[]
      */
     public function read(string $productNumber, ?string $languageId): array

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -14,17 +14,18 @@ use Shopware\Core\Framework\Uuid\Uuid;
 class FeedPreprocessorEntryReader
 {
     private SalesChannelService $channelService;
-    private EntityRepositoryInterface $feedPreprocessorEntryRepository;
+    private EntityRepositoryInterface $entryRepository;
 
     public function __construct(
         SalesChannelService $channelService,
-        EntityRepositoryInterface $feedPreprocessorEntryRepository
+        EntityRepositoryInterface $entryRepository
     ) {
         $this->channelService                  = $channelService;
-        $this->feedPreprocessorEntryRepository = $feedPreprocessorEntryRepository;
+        $this->entryRepository = $entryRepository;
     }
 
     /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
      * @return FeedPreprocessorEntry[]
      */
     public function read(string $productNumber, ?string $languageId): array
@@ -37,7 +38,7 @@ class FeedPreprocessorEntryReader
             $criteria->addFilter(new EqualsFilter('languageId', Uuid::fromHexToBytes($context->getLanguageId())));
         }
 
-        $preprocessedFeeds = $this->feedPreprocessorEntryRepository->search($criteria, $context)->getElements();
+        $preprocessedFeeds = $this->entryRepository->search($criteria, $context)->getElements();
 
         return array_reduce($preprocessedFeeds, function (array $acc, FeedPreprocessorEntry $preprocessedFeed) {
             $number = $preprocessedFeed->getProductNumber();

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -20,7 +20,7 @@ class FeedPreprocessorEntryReader
         SalesChannelService $channelService,
         EntityRepositoryInterface $feedPreprocessorEntryRepository
     ) {
-        $this->channelService = $channelService;
+        $this->channelService                  = $channelService;
         $this->feedPreprocessorEntryRepository = $feedPreprocessorEntryRepository;
     }
 
@@ -29,7 +29,7 @@ class FeedPreprocessorEntryReader
      */
     public function read(string $productNumber, ?string $languageId): array
     {
-        $context = $this->channelService->getSalesChannelContext()->getContext();
+        $context  = $this->channelService->getSalesChannelContext()->getContext();
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
 

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -6,7 +6,6 @@ namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
 
 use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
 use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
-use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -27,11 +26,17 @@ class FeedPreprocessorEntryReader
     /**
      * @return FeedPreprocessorEntry[]
      */
-    public function read(string $productNumber): array
+    public function read(string $productNumber, string $languageId = ''): array
     {
         $context = $this->channelService->getSalesChannelContext()->getContext();
+
+        if ($languageId === '') {
+            $languageId = $context->getLanguageId();
+        }
+
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
+        $criteria->addFilter(new EqualsFilter('languageId', $languageId));
         $preprocessedFeeds = $this->feedPreprocessorEntryRepository->search($criteria, $context)->getElements();
 
         return array_reduce($preprocessedFeeds, function (array $acc, FeedPreprocessorEntry $preprocessedFeed) {

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -36,7 +36,7 @@ class FeedPreprocessorEntryReader
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
-        $criteria->addFilter(new EqualsFilter('languageId', $languageId));
+//        $criteria->addFilter(new EqualsFilter('languageId', $languageId));
         $preprocessedFeeds = $this->feedPreprocessorEntryRepository->search($criteria, $context)->getElements();
 
         return array_reduce($preprocessedFeeds, function (array $acc, FeedPreprocessorEntry $preprocessedFeed) {

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -9,6 +9,7 @@ use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
 
 class FeedPreprocessorEntryReader
 {
@@ -26,17 +27,16 @@ class FeedPreprocessorEntryReader
     /**
      * @return FeedPreprocessorEntry[]
      */
-    public function read(string $productNumber, string $languageId = ''): array
+    public function read(string $productNumber, ?string $languageId): array
     {
         $context = $this->channelService->getSalesChannelContext()->getContext();
-
-        if ($languageId === '') {
-            $languageId = $context->getLanguageId();
-        }
-
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
-//        $criteria->addFilter(new EqualsFilter('languageId', $languageId));
+
+        if ($languageId) {
+            $criteria->addFilter(new EqualsFilter('languageId', Uuid::fromHexToBytes($context->getLanguageId())));
+        }
+
         $preprocessedFeeds = $this->feedPreprocessorEntryRepository->search($criteria, $context)->getElements();
 
         return array_reduce($preprocessedFeeds, function (array $acc, FeedPreprocessorEntry $preprocessedFeed) {

--- a/src/Events/FeedPreprocessorEntryBeforeCreate.php
+++ b/src/Events/FeedPreprocessorEntryBeforeCreate.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Events;
+
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareEvent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class FeedPreprocessorEntryBeforeCreate extends Event implements ShopwareEvent
+{
+    private FeedPreprocessorEntry $feedPreprocessorEntry;
+    private Context $context;
+
+    public function __construct(FeedPreprocessorEntry $entry, Context $context)
+    {
+        $this->entry   = $entry;
+        $this->context = $context;
+    }
+
+    public function getEntry(): FeedPreprocessorEntry
+    {
+        return $this->entry;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+}

--- a/src/Events/FeedPreprocessorEntryBeforeCreate.php
+++ b/src/Events/FeedPreprocessorEntryBeforeCreate.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Events;
 
-use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\ShopwareEvent;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -30,7 +29,7 @@ class FeedPreprocessorEntryBeforeCreate extends Event implements ShopwareEvent
         return $this->context;
     }
 
-    public function setEntry(array $entry) :void
+    public function setEntry(array $entry): void
     {
         $this->entry = $entry;
     }

--- a/src/Events/FeedPreprocessorEntryBeforeCreate.php
+++ b/src/Events/FeedPreprocessorEntryBeforeCreate.php
@@ -11,16 +11,16 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class FeedPreprocessorEntryBeforeCreate extends Event implements ShopwareEvent
 {
-    private FeedPreprocessorEntry $feedPreprocessorEntry;
+    private array $feedPreprocessorEntry;
     private Context $context;
 
-    public function __construct(FeedPreprocessorEntry $entry, Context $context)
+    public function __construct(array $entry, Context $context)
     {
         $this->entry   = $entry;
         $this->context = $context;
     }
 
-    public function getEntry(): FeedPreprocessorEntry
+    public function getEntry(): array
     {
         return $this->entry;
     }
@@ -28,5 +28,10 @@ class FeedPreprocessorEntryBeforeCreate extends Event implements ShopwareEvent
     public function getContext(): Context
     {
         return $this->context;
+    }
+
+    public function setEntry(array $entry) :void
+    {
+        $this->entry = $entry;
     }
 }

--- a/src/Events/FeedPreprocessorEntryBeforeCreate.php
+++ b/src/Events/FeedPreprocessorEntryBeforeCreate.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class FeedPreprocessorEntryBeforeCreate extends Event implements ShopwareEvent
 {
-    private array $feedPreprocessorEntry;
+    private array $entry;
     private Context $context;
 
     public function __construct(array $entry, Context $context)

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -14,7 +14,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
     private Product $product;
     private string $filterAttributes = '';
     private string $customFields = '';
-    private \Traversable $additionalCache;
+    private iterable $additionalCache = [];
 
     /** @var FieldInterface[] */
     private iterable $productFields;
@@ -47,7 +47,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
         return $this->filterAttributes;
     }
 
-    public function getAdditionalCache(): \Traversable
+    public function getAdditionalCache(): iterable
     {
         return $this->additionalCache;
     }
@@ -57,7 +57,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
         $this->filterAttributes = $filterAttributes;
     }
 
-    public function setAdditionalCache(\Traversable $additionalCache): void
+    public function setAdditionalCache(iterable $additionalCache): void
     {
         $this->additionalCache = $additionalCache;
     }

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -29,7 +29,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
         Traversable $cachedProductFields
     ) {
         $this->product             = $product;
-        $this->productFields       = $productFields;
+        $this->productFields       = iterator_to_array($productFields);
         $this->cachedProductFields = $cachedProductFields;
     }
 

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -73,7 +73,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 
     public function toArray(): array
     {
-        $cachedProductFieldNames = array_map(fn(FieldInterface $field) => $field->getName(), iterator_to_array($this->cachedProductFields));
+        $cachedProductFieldNames = array_map(fn(FieldInterface $field) => $field->getName(), iterator_to_array(new \ArrayIterator($this->cachedProductFields)));
         $fields = array_filter($this->productFields, fn (FieldInterface $productField) => !in_array($productField->getName(), $cachedProductFieldNames));
 
         return array_reduce($fields, fn (array $fields, FieldInterface $field): array => $fields + [$field->getName() => $field->getValue($this->product)], [

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -14,7 +14,7 @@ use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;
 class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 {
     private Product $product;
-    private ?Product $parent = null;
+    private ?Product $parent         = null;
     private string $filterAttributes = '';
     private string $customFields     = '';
     private Traversable $additionalCache;

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Export\Data\Entity;
 
+use ArrayIterator;
 use Omikron\FactFinder\Shopware6\Export\Data\ExportEntityInterface;
 use Omikron\FactFinder\Shopware6\Export\Field\FieldInterface;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
@@ -31,6 +32,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
         $this->product             = $product;
         $this->productFields       = iterator_to_array($productFields);
         $this->cachedProductFields = $cachedProductFields;
+        $this->additionalCache     = new ArrayIterator();
     }
 
     public function getId(): string
@@ -87,8 +89,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 
         return array_reduce(
             $fields,
-            fn (array $fields, FieldInterface $field): array => $fields
-                + [$field->getName() => ($this->getAdditionalCache($field->getName()) ?? $field->getValue($this->product))],
+            fn (array $fields, FieldInterface $field): array => $fields + [$field->getName() => ($this->getAdditionalCache($field->getName()) ?? $field->getValue($this->product))],
             $defaultFields
         );
     }

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -8,17 +8,27 @@ use Omikron\FactFinder\Shopware6\Export\Data\ExportEntityInterface;
 use Omikron\FactFinder\Shopware6\Export\Field\FieldInterface;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
 
-class ProductEntity implements ExportEntityInterface
+class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 {
     private Product $product;
+    private string $filterAttributes = '';
+    private string $customFields = '';
+    private array $additionalCache = [];
 
     /** @var FieldInterface[] */
     private iterable $productFields;
 
-    public function __construct(Product $product, iterable $productFields)
-    {
-        $this->product       = $product;
-        $this->productFields = $productFields;
+    /** @var FieldInterface[] */
+    private iterable $cachedProductFields;
+
+    public function __construct(
+        Product $product,
+        iterable $productFields,
+        iterable $cachedProductFields
+    ) {
+        $this->product             = $product;
+        $this->productFields       = $productFields;
+        $this->cachedProductFields = $cachedProductFields;
     }
 
     public function getId(): string
@@ -26,12 +36,52 @@ class ProductEntity implements ExportEntityInterface
         return $this->product->getId();
     }
 
+    public function getProductNumber(): string
+    {
+        return $this->product->getProductNumber();
+    }
+
+    public function getFilterAttributes(): string
+    {
+        return $this->filterAttributes;
+    }
+
+    public function getAdditionalCache(): array
+    {
+        return $this->additionalCache;
+    }
+
+    public function setFilterAttributes(string $filterAttributes): void
+    {
+        $this->filterAttributes = $filterAttributes;
+    }
+
+    public function setAdditionalCache(array $additionalCache): void
+    {
+        $this->additionalCache = $additionalCache;
+    }
+
+    public function getCustomFields(): string
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(string $customFields): void
+    {
+        $this->customFields = $customFields;
+    }
+
     public function toArray(): array
     {
-        return array_reduce($this->productFields, fn (array $fields, FieldInterface $field): array => $fields + [$field->getName() => $field->getValue($this->product)], [
-            'ProductNumber' => $this->product->getProductNumber(),
-            'Master'        => $this->product->getProductNumber(),
-            'Name'          => (string) $this->product->getTranslation('name'),
+        $cachedProductFieldNames = array_map(fn(FieldInterface $field) => $field->getName(), iterator_to_array($this->cachedProductFields));
+        $fields = array_filter($this->productFields, fn (FieldInterface $productField) => !in_array($productField->getName(), $cachedProductFieldNames));
+
+        return array_reduce($fields, fn (array $fields, FieldInterface $field): array => $fields + [$field->getName() => $field->getValue($this->product)], [
+            'ProductNumber'    => $this->product->getProductNumber(),
+            'Master'           => $this->product->getProductNumber(),
+            'Name'             => (string) $this->product->getTranslation('name'),
+            'FilterAttributes' => $this->getFilterAttributes(),
+            'CustomFields'     => $this->getCustomFields(),
         ]);
     }
 }

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -13,7 +13,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
     private Product $product;
     private string $filterAttributes = '';
     private string $customFields = '';
-    private array $additionalCache = [];
+    private \Traversable $additionalCache;
 
     /** @var FieldInterface[] */
     private iterable $productFields;
@@ -24,7 +24,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
     public function __construct(
         Product $product,
         iterable $productFields,
-        iterable $cachedProductFields
+        \Traversable $cachedProductFields
     ) {
         $this->product             = $product;
         $this->productFields       = $productFields;
@@ -46,7 +46,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
         return $this->filterAttributes;
     }
 
-    public function getAdditionalCache(): array
+    public function getAdditionalCache(): \Traversable
     {
         return $this->additionalCache;
     }
@@ -56,7 +56,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
         $this->filterAttributes = $filterAttributes;
     }
 
-    public function setAdditionalCache(array $additionalCache): void
+    public function setAdditionalCache(\Traversable $additionalCache): void
     {
         $this->additionalCache = $additionalCache;
     }
@@ -73,7 +73,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 
     public function toArray(): array
     {
-        $cachedProductFieldNames = array_map(fn(FieldInterface $field) => $field->getName(), iterator_to_array(new \ArrayIterator($this->cachedProductFields)));
+        $cachedProductFieldNames = array_map(fn(FieldInterface $field) => $field->getName(), iterator_to_array($this->cachedProductFields));
         $fields = array_filter($this->productFields, fn (FieldInterface $productField) => !in_array($productField->getName(), $cachedProductFieldNames));
 
         return array_reduce($fields, fn (array $fields, FieldInterface $field): array => $fields + [$field->getName() => $field->getValue($this->product)], [

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -7,14 +7,14 @@ namespace Omikron\FactFinder\Shopware6\Export\Data\Entity;
 use Omikron\FactFinder\Shopware6\Export\Data\ExportEntityInterface;
 use Omikron\FactFinder\Shopware6\Export\Field\FieldInterface;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
-use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;
 use Traversable;
+use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;
 
 class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 {
     private Product $product;
     private string $filterAttributes = '';
-    private string $customFields = '';
+    private string $customFields     = '';
     private Traversable $additionalCache;
 
     /** @var FieldInterface[] */
@@ -75,9 +75,9 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 
     public function toArray(): array
     {
-        $cachedProductFieldNames = array_map(fn(FieldInterface $field) => $field->getName(), iterator_to_array($this->cachedProductFields));
-        $fields = array_filter($this->productFields, fn (FieldInterface $productField) => !in_array($productField->getName(), $cachedProductFieldNames));
-        $defaultFields = [
+        $cachedProductFieldNames = array_map(fn (FieldInterface $field) => $field->getName(), iterator_to_array($this->cachedProductFields));
+        $fields                  = array_filter($this->productFields, fn (FieldInterface $productField) => !in_array($productField->getName(), $cachedProductFieldNames));
+        $defaultFields           = [
             'ProductNumber'    => $this->product->getProductNumber(),
             'Master'           => $this->product->getProductNumber(),
             'Name'             => (string) $this->product->getTranslation('name'),

--- a/src/Export/Data/Entity/ProductEntityInterface.php
+++ b/src/Export/Data/Entity/ProductEntityInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export\Data\Entity;
+
+interface ProductEntityInterface
+{
+    public function getProductNumber(): string;
+}

--- a/src/Export/Data/Entity/VariantEntity.php
+++ b/src/Export/Data/Entity/VariantEntity.php
@@ -10,7 +10,7 @@ use Omikron\FactFinder\Shopware6\Export\PropertyFormatter;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
 use function array_map as map;
 
-class VariantEntity implements ExportEntityInterface
+class VariantEntity implements ExportEntityInterface, ProductEntityInterface
 {
     private Product $product;
     private array $parentData;
@@ -34,6 +34,11 @@ class VariantEntity implements ExportEntityInterface
     public function getId(): string
     {
         return $this->product->getId();
+    }
+
+    public function getProductNumber(): string
+    {
+        return $this->product->getProductNumber();
     }
 
     public function toArray(): array

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -70,7 +70,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
             $cache = $preprocessedEntries[$child->getProductNumber()] ?? null;
 
             if (isset($cache)) {
-                $exportProduct = new ExportProductEntity($child, $fields, $this->cachedFields);
+                $exportProduct = new ExportProductEntity($child, new \ArrayIterator($fields), $this->cachedFields);
                 $exportProduct->setFilterAttributes($cache->getFilterAttributes());
                 $exportProduct->setCustomFields($cache->getCustomFields());
                 $exportProduct->setAdditionalCache(new \ArrayIterator($cache->getAdditionalCache()));

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -24,7 +24,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
         FieldsProvider $fieldsProviders,
         ExportSettings $exportSettings,
         FeedPreprocessorEntryReader $feedPreprocessorReader,
-        iterable $cachedFields
+        \Traversable $cachedFields
     ) {
         $this->decoratedFactory = $decoratedFactory;
         $this->fieldsProviders = $fieldsProviders;
@@ -43,11 +43,11 @@ class PreprocessedProductEntityFactory implements FactoryInterface
      */
     public function createEntities(Entity $entity, string $producedType = ExportProductEntity::class): iterable
     {
-//        if ($this->exportSettings->isExportCacheEnable() === false) {
-//            yield from $this->decoratedFactory->createEntities($entity, $producedType);
-//
-//            return;
-//        }
+        if ($this->exportSettings->isExportCacheEnable() === false) {
+            yield from $this->decoratedFactory->createEntities($entity, $producedType);
+
+            return;
+        }
 
         $preprocessedFeeds = $this->feedPreprocessorReader->read($entity->getProductNumber());
 
@@ -66,7 +66,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
                 $variant = new ExportProductEntity($child, $fields, $this->cachedFields);
                 $variant->setFilterAttributes($feeds->getFilterAttributes());
                 $variant->setCustomFields($feeds->getCustomFields());
-                $variant->setAdditionalCache($feeds->getAdditionalCache());
+                $variant->setAdditionalCache(new \ArrayIterator($feeds->getAdditionalCache()));
                 yield $variant;
             }
         }

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -57,7 +57,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
             return;
         }
 
-        $fields = $this->fieldsProviders->getFields(ExportProductEntity::class);
+        $fields = $this->fieldsProviders->getFields(SalesChannelProductEntity::class);
 
         foreach ($entity->getChildren() as $child) {
             $cache = $preprocessedFeeds[$child->getProductNumber()] ?? null;

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export\Data\Factory;
+
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryReader;
+use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
+use Omikron\FactFinder\Shopware6\Export\FieldsProvider;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+
+class PreprocessedProductEntityFactory implements FactoryInterface
+{
+    private FactoryInterface $decoratedFactory;
+    private FieldsProvider $fieldsProviders;
+    private FeedPreprocessorEntryReader $feedPreprocessorReader;
+    private iterable $cachedFields;
+
+    public function __construct(
+        FactoryInterface $decoratedFactory,
+        FieldsProvider $fieldsProviders,
+        FeedPreprocessorEntryReader $feedPreprocessorReader,
+        iterable $cachedFields
+    ) {
+        $this->decoratedFactory = $decoratedFactory;
+        $this->fieldsProviders = $fieldsProviders;
+        $this->feedPreprocessorReader = $feedPreprocessorReader;
+        $this->cachedFields = $cachedFields;
+    }
+
+    public function handle(Entity $entity): bool
+    {
+        return in_array(get_class($entity), [SalesChannelProductEntity::class]);
+    }
+
+    /**
+     * @return ExportProductEntity[]|iterable
+     */
+    public function createEntities(Entity $entity, string $producedType = ExportProductEntity::class): iterable
+    {
+        $preprocessedFeeds = $this->feedPreprocessorReader->read($entity->getProductNumber());
+
+        if ($preprocessedFeeds === []) {
+            yield from $this->decoratedFactory->createEntities($entity, $producedType);
+
+            return;
+        }
+
+        $fields = $this->fieldsProviders->getFields(get_class($entity));
+
+        foreach ($entity->getChildren() as $child) {
+            $feeds = $preprocessedFeeds[$child->getProductNumber()] ?? null;
+
+            if (isset($feeds)) {
+                $variant = new ExportProductEntity($child, $fields, $this->cachedFields);
+                $variant->setFilterAttributes($feeds->getFilterAttributes());
+                $variant->setCustomFields($feeds->getCustomFields());
+                $variant->setAdditionalCache($feeds->getAdditionalCache());
+                yield $variant;
+            }
+        }
+    }
+}

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -80,7 +80,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
         }
 
         if ($entity->getChildCount() === 0) {
-            $exportProduct = $this->getExportProduct($entity, $preprocessedEntries);
+            $exportProduct = $this->getExportProduct($entity, $entity, $preprocessedEntries);
 
             if (isset($exportProduct)) {
                 yield $exportProduct;
@@ -90,7 +90,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
         }
 
         foreach ($entity->getChildren() as $child) {
-            $exportProduct = $this->getExportProduct($child, $preprocessedEntries);
+            $exportProduct = $this->getExportProduct($child, $entity, $preprocessedEntries);
 
             if (isset($exportProduct)) {
                 yield $exportProduct;
@@ -101,7 +101,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
     /**
      * @param FeedPreprocessorEntry[] $preprocessedEntries
      */
-    private function getExportProduct(SalesChannelProductEntity $entity, array $preprocessedEntries): ?ExportProductEntity
+    private function getExportProduct(SalesChannelProductEntity $entity, SalesChannelProductEntity $parent, array $preprocessedEntries): ?ExportProductEntity
     {
         $fields = $this->fieldsProviders->getFields(SalesChannelProductEntity::class);
         $cache  = $preprocessedEntries[$entity->getProductNumber()] ?? null;
@@ -111,6 +111,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
             $exportProduct->setFilterAttributes($cache->getFilterAttributes());
             $exportProduct->setCustomFields($cache->getCustomFields());
             $exportProduct->setAdditionalCache(new ArrayIterator($cache->getAdditionalCache()));
+            $exportProduct->setParent($parent);
 
             return $exportProduct;
         }

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -12,6 +12,7 @@ use Omikron\FactFinder\Shopware6\Export\FieldsProvider;
 use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Traversable;
 
 class PreprocessedProductEntityFactory implements FactoryInterface
 {
@@ -28,14 +29,14 @@ class PreprocessedProductEntityFactory implements FactoryInterface
         FieldsProvider $fieldsProviders,
         ExportSettings $exportSettings,
         FeedPreprocessorEntryReader $feedPreprocessorReader,
-        \Traversable $cachedFields
+        Traversable $cachedFields
     ) {
-        $this->channelService = $channelService;
-        $this->decoratedFactory = $decoratedFactory;
-        $this->fieldsProviders = $fieldsProviders;
-        $this->exportSettings = $exportSettings;
+        $this->channelService         = $channelService;
+        $this->decoratedFactory       = $decoratedFactory;
+        $this->fieldsProviders        = $fieldsProviders;
+        $this->exportSettings         = $exportSettings;
         $this->feedPreprocessorReader = $feedPreprocessorReader;
-        $this->cachedFields = $cachedFields;
+        $this->cachedFields           = $cachedFields;
     }
 
     public function handle(Entity $entity): bool
@@ -90,7 +91,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
     private function getExportProduct(SalesChannelProductEntity $entity, array $preprocessedEntries): ?ExportProductEntity
     {
         $fields = $this->fieldsProviders->getFields(SalesChannelProductEntity::class);
-        $cache = $preprocessedEntries[$entity->getProductNumber()] ?? null;
+        $cache  = $preprocessedEntries[$entity->getProductNumber()] ?? null;
 
         if (isset($cache)) {
             $exportProduct = new ExportProductEntity($entity, new \ArrayIterator($fields), $this->cachedFields);

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -22,8 +22,8 @@ class PreprocessedProductEntityFactory implements FactoryInterface
     private iterable $cachedFields;
 
     public function __construct(
-        SalesChannelService $channelService,
         FactoryInterface $decoratedFactory,
+        SalesChannelService $channelService,
         FieldsProvider $fieldsProviders,
         ExportSettings $exportSettings,
         FeedPreprocessorEntryReader $feedPreprocessorReader,

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Export\Data\Factory;
 
+use ArrayIterator;
 use Omikron\FactFinder\Shopware6\Config\ExportSettings;
 use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryReader;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
@@ -94,10 +95,10 @@ class PreprocessedProductEntityFactory implements FactoryInterface
         $cache  = $preprocessedEntries[$entity->getProductNumber()] ?? null;
 
         if (isset($cache)) {
-            $exportProduct = new ExportProductEntity($entity, new \ArrayIterator($fields), $this->cachedFields);
+            $exportProduct = new ExportProductEntity($entity, new ArrayIterator($fields), $this->cachedFields);
             $exportProduct->setFilterAttributes($cache->getFilterAttributes());
             $exportProduct->setCustomFields($cache->getCustomFields());
-            $exportProduct->setAdditionalCache(new \ArrayIterator($cache->getAdditionalCache()));
+            $exportProduct->setAdditionalCache(new ArrayIterator($cache->getAdditionalCache()));
 
             return $exportProduct;
         }

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -43,11 +43,11 @@ class PreprocessedProductEntityFactory implements FactoryInterface
      */
     public function createEntities(Entity $entity, string $producedType = ExportProductEntity::class): iterable
     {
-        if ($this->exportSettings->isExportCacheEnable() === false) {
-            yield from $this->decoratedFactory->createEntities($entity, $producedType);
-
-            return;
-        }
+//        if ($this->exportSettings->isExportCacheEnable() === false) {
+//            yield from $this->decoratedFactory->createEntities($entity, $producedType);
+//
+//            return;
+//        }
 
         $preprocessedFeeds = $this->feedPreprocessorReader->read($entity->getProductNumber());
 

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -49,25 +49,25 @@ class PreprocessedProductEntityFactory implements FactoryInterface
             return;
         }
 
-        $preprocessedFeeds = $this->feedPreprocessorReader->read($entity->getProductNumber());
+        $preprocessedEntries = $this->feedPreprocessorReader->read($entity->getProductNumber());
 
-        if ($preprocessedFeeds === []) {
+        if ($preprocessedEntries === []) {
             yield from $this->decoratedFactory->createEntities($entity, $producedType);
 
             return;
         }
 
-        $fields = $this->fieldsProviders->getFields(get_class($entity));
+        $fields = $this->fieldsProviders->getFields(ExportProductEntity::class);
 
         foreach ($entity->getChildren() as $child) {
-            $feeds = $preprocessedFeeds[$child->getProductNumber()] ?? null;
+            $cache = $preprocessedFeeds[$child->getProductNumber()] ?? null;
 
-            if (isset($feeds)) {
-                $variant = new ExportProductEntity($child, $fields, $this->cachedFields);
-                $variant->setFilterAttributes($feeds->getFilterAttributes());
-                $variant->setCustomFields($feeds->getCustomFields());
-                $variant->setAdditionalCache(new \ArrayIterator($feeds->getAdditionalCache()));
-                yield $variant;
+            if (isset($cache)) {
+                $exportProduct = new ExportProductEntity($child, $fields, $this->cachedFields);
+                $exportProduct->setFilterAttributes($cache->getFilterAttributes());
+                $exportProduct->setCustomFields($cache->getCustomFields());
+                $exportProduct->setAdditionalCache(new \ArrayIterator($cache->getAdditionalCache()));
+                yield $exportProduct;
             }
         }
     }

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -60,7 +60,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
         $fields = $this->fieldsProviders->getFields(SalesChannelProductEntity::class);
 
         foreach ($entity->getChildren() as $child) {
-            $cache = $preprocessedFeeds[$child->getProductNumber()] ?? null;
+            $cache = $preprocessedEntries[$child->getProductNumber()] ?? null;
 
             if (isset($cache)) {
                 $exportProduct = new ExportProductEntity($child, $fields, $this->cachedFields);

--- a/src/Export/Data/Factory/ProductEntityFactory.php
+++ b/src/Export/Data/Factory/ProductEntityFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Export\Data\Factory;
 
+use ArrayIterator;
 use Omikron\FactFinder\Shopware6\Export\CurrencyFieldsProvider;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\VariantEntity;
@@ -48,7 +49,7 @@ class ProductEntityFactory implements FactoryInterface
     {
         //@todo use spread operator?
         $fields = array_merge($this->fieldsProvider->getFields(get_class($entity), $this->currencyFieldsProvider->getCurrencyFields()));
-        $parent = new $producedType($entity, $fields, new \ArrayIterator());
+        $parent = new $producedType($entity, $fields, new ArrayIterator());
         if ($entity->getChildCount()) {
             yield from $entity->getChildren()->map(fn (
                 SalesChannelProductEntity $child) => new VariantEntity($child, $parent->toArray(), $this->propertyFormatter, iterator_to_array($this->variantFields)));

--- a/src/Export/Data/Factory/ProductEntityFactory.php
+++ b/src/Export/Data/Factory/ProductEntityFactory.php
@@ -48,7 +48,7 @@ class ProductEntityFactory implements FactoryInterface
     {
         //@todo use spread operator?
         $fields = array_merge($this->fieldsProvider->getFields(get_class($entity), $this->currencyFieldsProvider->getCurrencyFields()));
-        $parent = new $producedType($entity, $fields);
+        $parent = new $producedType($entity, $fields, new \ArrayIterator());
         if ($entity->getChildCount()) {
             yield from $entity->getChildren()->map(fn (
                 SalesChannelProductEntity $child) => new VariantEntity($child, $parent->toArray(), $this->propertyFormatter, iterator_to_array($this->variantFields)));

--- a/src/Export/Data/Factory/ProductEntityFactory.php
+++ b/src/Export/Data/Factory/ProductEntityFactory.php
@@ -49,7 +49,7 @@ class ProductEntityFactory implements FactoryInterface
     {
         //@todo use spread operator?
         $fields = array_merge($this->fieldsProvider->getFields(get_class($entity), $this->currencyFieldsProvider->getCurrencyFields()));
-        $parent = new $producedType($entity, $fields, new ArrayIterator());
+        $parent = new $producedType($entity, new ArrayIterator($fields), new ArrayIterator());
         if ($entity->getChildCount()) {
             yield from $entity->getChildren()->map(fn (
                 SalesChannelProductEntity $child) => new VariantEntity($child, $parent->toArray(), $this->propertyFormatter, iterator_to_array($this->variantFields)));

--- a/src/Export/Data/Factory/ProductEntityFactory.php
+++ b/src/Export/Data/Factory/ProductEntityFactory.php
@@ -26,10 +26,10 @@ class ProductEntityFactory implements FactoryInterface
         CurrencyFieldsProvider $currencyFieldsProvider,
         Traversable $variantFields
     ) {
-        $this->propertyFormatter      = $propertyFormatter;
-        $this->fieldsProvider         = $fieldsProviders;
-        $this->variantFields          = $variantFields;
-        $this->currencyFieldsProvider = $currencyFieldsProvider;
+        $this->propertyFormatter               = $propertyFormatter;
+        $this->fieldsProvider                  = $fieldsProviders;
+        $this->variantFields                   = $variantFields;
+        $this->currencyFieldsProvider          = $currencyFieldsProvider;
     }
 
     public function handle(Entity $entity): bool
@@ -41,7 +41,7 @@ class ProductEntityFactory implements FactoryInterface
      * @param Entity $entity
      * @param string $producedType
      *
-     * @return iterable
+     * @return ProductEntity[]|iterable
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function createEntities(Entity $entity, string $producedType = ProductEntity::class): iterable

--- a/src/Export/FeedPreprocessorEntry.php
+++ b/src/Export/FeedPreprocessorEntry.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+
+class FeedPreprocessorEntry extends Entity
+{
+    protected ?string $id;
+    protected ?string $productNumber;
+    protected ?string $parentProductNumber;
+    protected ?string $variationKey;
+    protected ?string $filterAttributes;
+    protected ?string $customFields;
+    protected ?string $languageId;
+    protected array $additionalCache = [];
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setId(?string $id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getLanguageId(): ?string
+    {
+        return $this->languageId;
+    }
+
+    public function setLanguageId(?string $languageId): self
+    {
+        $this->languageId = $languageId;
+        return $this;
+    }
+
+    public function getProductNumber(): ?string
+    {
+        return $this->productNumber;
+    }
+
+    public function setProductNumber(?string $productNumber): self
+    {
+        $this->productNumber = $productNumber;
+        return $this;
+    }
+
+    public function getParentProductNumber(): ?string
+    {
+        return $this->parentProductNumber;
+    }
+
+    public function setParentProductNumber(?string $parentProductNumber): self
+    {
+        $this->parentProductNumber = $parentProductNumber;
+        return $this;
+    }
+
+    public function getVariationKey(): ?string
+    {
+        return $this->variationKey;
+    }
+
+    public function setVariationKey(?string $variationKey): self
+    {
+        $this->variationKey = $variationKey;
+        return $this;
+    }
+
+    public function getFilterAttributes(): ?string
+    {
+        return $this->filterAttributes;
+    }
+
+    public function setFilterAttributes(?string $filterAttributes): self
+    {
+        $this->filterAttributes = $filterAttributes;
+        return $this;
+    }
+
+    public function getCustomFields(): ?string
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(?string $customFields): self
+    {
+        $this->customFields = $customFields;
+        return $this;
+    }
+
+    public function getAdditionalCache(): ?array
+    {
+        return $this->additionalCache;
+    }
+
+    public function setAdditionalCache(?array $additionalCache): self
+    {
+        $this->additionalCache = $additionalCache;
+        return $this;
+    }
+}

--- a/src/Export/FeedPreprocessorEntry.php
+++ b/src/Export/FeedPreprocessorEntry.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Export;

--- a/src/Export/FeedPreprocessorEntryCollection.php
+++ b/src/Export/FeedPreprocessorEntryCollection.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void               add(ExampleEntity $entity)
+ * @method void               set(string $key, ExampleEntity $entity)
+ * @method FeedPreprocessorEntry[]    getIterator()
+ * @method FeedPreprocessorEntry[]    getElements()
+ * @method FeedPreprocessorEntry|null get(string $key)
+ * @method FeedPreprocessorEntry|null first()
+ * @method FeedPreprocessorEntry|null last()
+ */
+class FeedPreprocessorEntryCollection extends EntityCollection
+{
+    public function getExpectedClass(): string
+    {
+        return FeedPreprocessorEntry::class;
+    }
+}

--- a/src/Export/FeedPreprocessorEntryCollection.php
+++ b/src/Export/FeedPreprocessorEntryCollection.php
@@ -7,8 +7,8 @@ namespace Omikron\FactFinder\Shopware6\Export;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 
 /**
- * @method void               add(ExampleEntity $entity)
- * @method void               set(string $key, ExampleEntity $entity)
+ * @method void                       add(ExampleEntity $entity)
+ * @method void                       set(string $key, ExampleEntity $entity)
  * @method FeedPreprocessorEntry[]    getIterator()
  * @method FeedPreprocessorEntry[]    getElements()
  * @method FeedPreprocessorEntry|null get(string $key)

--- a/src/Export/FeedPreprocessorEntryDefinition.php
+++ b/src/Export/FeedPreprocessorEntryDefinition.php
@@ -42,7 +42,7 @@ class FeedPreprocessorEntryDefinition extends EntityDefinition
                 (new StringField('parent_product_number', 'parentProductNumber')),
                 (new StringField('variation_key', 'variationKey')),
                 (new StringField('filter_attributes', 'filterAttributes'))->addFlags(new Required(), new AllowEmptyString()),
-                (new StringField('custom_fields', 'customFields')),
+                (new StringField('custom_fields', 'customFields'))->addFlags(new AllowEmptyString()),
                 (new JsonField('additional_cache', 'additionalCache')),
             ]
         );

--- a/src/Export/FeedPreprocessorEntryDefinition.php
+++ b/src/Export/FeedPreprocessorEntryDefinition.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class FeedPreprocessorEntryDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'factfinder_feed_preprocessor';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getEntityClass(): string
+    {
+        return FeedPreprocessorEntry::class;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return FeedPreprocessorEntryCollection::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection(
+            [
+                (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+                (new StringField('language_id', 'languageId'))->addFlags(new Required()),
+                (new StringField('product_number', 'productNumber'))->addFlags(new Required()),
+                (new StringField('parent_product_number', 'parentProductNumber')),
+                (new StringField('variation_key', 'variationKey')),
+                (new StringField('filter_attributes', 'filterAttributes'))->addFlags(new Required()),
+                (new StringField('custom_fields', 'customFields')),
+                (new JsonField('additional_cache', 'additionalCache')),
+            ]
+        );
+    }
+}

--- a/src/Export/FeedPreprocessorEntryDefinition.php
+++ b/src/Export/FeedPreprocessorEntryDefinition.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\Export;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowEmptyString;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
@@ -40,7 +41,7 @@ class FeedPreprocessorEntryDefinition extends EntityDefinition
                 (new StringField('product_number', 'productNumber'))->addFlags(new Required()),
                 (new StringField('parent_product_number', 'parentProductNumber')),
                 (new StringField('variation_key', 'variationKey')),
-                (new StringField('filter_attributes', 'filterAttributes'))->addFlags(new Required()),
+                (new StringField('filter_attributes', 'filterAttributes'))->addFlags(new Required(), new AllowEmptyString()),
                 (new StringField('custom_fields', 'customFields')),
                 (new JsonField('additional_cache', 'additionalCache')),
             ]

--- a/src/Export/Field/CategoryPath.php
+++ b/src/Export/Field/CategoryPath.php
@@ -34,6 +34,10 @@ class CategoryPath implements FieldInterface
 
     public function getValue(Entity $entity): string
     {
+        if ($entity->getCategories() === null) {
+            return '';
+        }
+
         return implode('|', $entity->getCategories()->fmap($this->createPath($this->channelService->getSalesChannelContext()->getSalesChannel())));
     }
 

--- a/src/Export/Field/CustomFields.php
+++ b/src/Export/Field/CustomFields.php
@@ -63,14 +63,16 @@ class CustomFields implements FieldInterface
 
     public function getValue(Entity $entity): string
     {
-        return $this->getFieldValue($entity);
+        $value = $this->getFieldValueAsArray($entity);
+
+        return $value ? '|' . implode('|', $value) . '|' : '';
     }
 
     public function getValueAsKeyValueArray(Entity $entity): array
     {
         return array_reduce(
             $this->getFieldValueAsArray($entity),
-            function(array $carriedValues, string $customFieldValue) {
+            function (array $carriedValues, string $customFieldValue) {
                 $separatorPosition = strpos($customFieldValue, '=');
                 $key = substr($customFieldValue, 0, $separatorPosition);
                 $value = substr($customFieldValue, $separatorPosition + 1, strlen($customFieldValue));
@@ -85,13 +87,6 @@ class CustomFields implements FieldInterface
     public function getCompatibleEntityTypes(): array
     {
         return [SalesChannelProductEntity::class, CategoryEntity::class];
-    }
-
-    private function getFieldValue(Entity $entity): string
-    {
-        $value = $this->getFieldValueAsArray($entity);
-
-        return $value ? '|' . implode('|', $value) . '|' : '';
     }
 
     private function getFieldValueAsArray(Entity $entity): array

--- a/src/Export/Field/CustomFields.php
+++ b/src/Export/Field/CustomFields.php
@@ -73,9 +73,9 @@ class CustomFields implements FieldInterface
         return array_reduce(
             $this->getFieldValueAsArray($entity),
             function (array $carriedValues, string $customFieldValue) {
-                $separatorPosition = strpos($customFieldValue, '=');
-                $key = substr($customFieldValue, 0, $separatorPosition);
-                $value = substr($customFieldValue, $separatorPosition + 1, strlen($customFieldValue));
+                $separatorPosition   = strpos($customFieldValue, '=');
+                $key                 = substr($customFieldValue, 0, $separatorPosition);
+                $value               = substr($customFieldValue, $separatorPosition + 1, strlen($customFieldValue));
                 $carriedValues[$key] = $value;
 
                 return $carriedValues;
@@ -127,7 +127,7 @@ class CustomFields implements FieldInterface
 
                 //select types not necessarily must have 'options', entity selectors don't have it
                 if ($customField->getType() === CustomFieldTypes::SELECT && isset($config['options'])) {
-                    $options               = array_filter($config['options'], fn (
+                    $options = array_filter($config['options'], fn (
                         array $option): bool => is_array($storedValue) ? in_array($option['value'], $storedValue) : $option['value'] === $storedValue);
                     $translatedOptionValue = $formatManyValues(map($formatLabel, $options));
                 }

--- a/src/Export/Field/CustomFields.php
+++ b/src/Export/Field/CustomFields.php
@@ -66,12 +66,35 @@ class CustomFields implements FieldInterface
         return $this->getFieldValue($entity);
     }
 
+    public function getValueAsKeyValueArray(Entity $entity): array
+    {
+        return array_reduce(
+            $this->getFieldValueAsArray($entity),
+            function(array $carriedValues, string $customFieldValue) {
+                $separatorPosition = strpos($customFieldValue, '=');
+                $key = substr($customFieldValue, 0, $separatorPosition);
+                $value = substr($customFieldValue, $separatorPosition + 1, strlen($customFieldValue));
+                $carriedValues[$key] = $value;
+
+                return $carriedValues;
+            },
+            []
+        );
+    }
+
     public function getCompatibleEntityTypes(): array
     {
         return [SalesChannelProductEntity::class, CategoryEntity::class];
     }
 
-    public function getFieldValue(Entity $entity): string
+    private function getFieldValue(Entity $entity): string
+    {
+        $value = $this->getFieldValueAsArray($entity);
+
+        return $value ? '|' . implode('|', $value) . '|' : '';
+    }
+
+    private function getFieldValueAsArray(Entity $entity): array
     {
         $fields        = $this->getFields($entity);
         $usedLocale    = $this->findLanguage($this->salesChannelService->getSalesChannelContext()->getSalesChannel()->getLanguageId())->getLocale()->getCode();
@@ -83,9 +106,7 @@ class CustomFields implements FieldInterface
             array_values($fields)
         );
 
-        $value = map([$this->propertyFormatter, 'format'], array_keys($translatedFields), array_values($translatedFields));
-
-        return $value ? '|' . implode('|', $value) . '|' : '';
+        return map([$this->propertyFormatter, 'format'], array_keys($translatedFields), array_values($translatedFields));
     }
 
     /**

--- a/src/Export/Field/Deeplink.php
+++ b/src/Export/Field/Deeplink.php
@@ -38,6 +38,10 @@ class Deeplink implements FieldInterface, EventSubscriberInterface
 
     public function getValue(Entity $entity): string
     {
+        if ($entity->getSeoUrls() === null) {
+            return '';
+        }
+
         $url                = $entity->getSeoUrls()->first();
         $getSeoUrlRouteName = fn (Entity $entity) => $entity instanceof ProductEntity ? ProductRoute::ROUTE_NAME : CategoryRoute::ROUTE_NAME;
         $formUrl            = fn (string $url): string => $url ? '/' . ltrim($url, '/') : '';

--- a/src/Migration/Migration1657582730Preprocessor.php
+++ b/src/Migration/Migration1657582730Preprocessor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1657582730Preprocessor extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1657582730;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $query = <<<SQL
+CREATE TABLE IF NOT EXISTS `factfinder_feed_preprocessor` (
+    `id`                           BINARY(16)               NOT NULL,
+    `language_id`                  BINARY(16)               NOT NULL,
+    `product_number`               VARCHAR(255)             NOT NULL,
+    `parent_product_number`        VARCHAR(255),
+    `variation_key`                VARCHAR(255),
+    `filter_attributes`            LONGTEXT                 NOT NULL,
+    `custom_fields`                LONGTEXT                 NOT NULL,
+    `additional_cache`             JSON,
+    `created_at` DATETIME(3) NOT NULL,
+    `updated_at` DATETIME(3),
+    PRIMARY KEY (id)
+)
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_unicode_ci;
+SQL;
+
+        $connection->executeStatement($query);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        $query = <<<SQL
+DROP TABLE IF EXISTS `factfinder_feed_preprocessor`
+SQL;
+        $connection->executeStatement($query);
+    }
+}

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -57,6 +57,11 @@
             <name>currencyPriceExport</name>
             <label>Export Prices for all Currencies</label>
         </input-field>
+
+        <input-field type="checkbox">
+            <name>enableExportCache</name>
+            <label>Enable export cache (decrease export time)</label>
+        </input-field>
     </card>
 
     <card>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -140,5 +140,9 @@
                  decorates="Omikron\FactFinder\Shopware6\Export\Data\Factory\ProductEntityFactory">
             <argument type="service" id="Omikron\FactFinder\Shopware6\Export\Data\Factory\PreprocessedProductEntityFactory.inner"/>
         </service>
+
+        <service id="Omikron\FactFinder\Shopware6\Subscriber\FeedPreprocessorEntrySubscriber">
+            <argument type="service" id="product.repository"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -58,11 +58,13 @@
             <bind key="$customFieldRepository" type="service" id="custom_field.repository" />
             <bind key="$languageRepository" type="service" id="language.repository"/>
             <bind key="$variantFields" type="tagged_iterator" tag="factfinder.export.variant_field" />
+            <bind key="$cachedFields" type="tagged_iterator" tag="factfinder.export.cached_product_entity" />
             <bind key="$categoryPathFieldName">%factfinder.navigation.category_path_field_name%</bind>
             <bind key="$customAssociations">%factfinder.export.associations%</bind>
             <bind key="$categoryPageAddParams">%factfinder.category_page.add_params%</bind>
             <bind key="$configurationAddParams">%factfinder.configuration.add_params%</bind>
             <bind key="$communicationParameters">%factfinder.communication.parameters.base%</bind>
+            <bind key="$feedPreprocessorEntryRepository" type="service" id="factfinder_feed_preprocessor.repository" />
         </defaults>
 
         <service id="Omikron\FactFinder\Communication\Resource\AdapterFactory" />
@@ -87,7 +89,7 @@
         </instanceof>
 
         <prototype namespace="Omikron\FactFinder\Shopware6\"
-                   resource="../../{Command,Communication,Config,Data,Export,Resources,Storefront,Subscriber,Upload,Service}"
+                   resource="../../{Command,Communication,Config,Data,Export,Resources,Storefront,Subscriber,Upload,Service,DataAbstractionLayer}"
                    exclude="../../Export/Field/{PriceCurrency}.php"
         />
 
@@ -104,9 +106,13 @@
 
         <service id="Omikron\FactFinder\Shopware6\Export\Field\CustomFields">
             <tag name="factfinder.export.variant_field"/>
+            <tag name="factfinder.export.cached_product_entity"/>
         </service>
         <service id="Omikron\FactFinder\Shopware6\Export\Field\ImageUrl">
             <tag name="factfinder.export.variant_field"/>
+        </service>
+        <service id="Omikron\FactFinder\Shopware6\Export\Field\FilterAttributes">
+            <tag name="factfinder.export.cached_product_entity"/>
         </service>
         <service id="Omikron\FactFinder\Shopware6\Api\UiFeedExportController" />
         <service id="Omikron\FactFinder\Shopware6\Api\UpdateFieldRolesController" />
@@ -119,5 +125,20 @@
         </service>
         <service id="Omikron\FactFinder\Shopware6\Config\Communication" public="true"/>
         <service id="Omikron\FactFinder\Shopware6\Config\FieldRoles" public="true"/>
+
+        <service id="Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntryDefinition">
+            <tag name="shopware.entity.definition" entity="factfinder_feed_preprocessor" /></service>
+
+        <service id="Omikron\FactFinder\Shopware6\Subscriber\ProductIndexerSubscriber">
+            <argument type="service" id="product.repository"/>
+            <argument type="service" id="language.repository"/>
+            <argument type="service" id="Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessor"/>
+            <argument type="service" id="Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryPersister"/>
+        </service>
+
+        <service id="Omikron\FactFinder\Shopware6\Export\Data\Factory\PreprocessedProductEntityFactory"
+                 decorates="Omikron\FactFinder\Shopware6\Export\Data\Factory\ProductEntityFactory">
+            <argument type="service" id="Omikron\FactFinder\Shopware6\Export\Data\Factory\PreprocessedProductEntityFactory.inner"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -64,7 +64,7 @@
             <bind key="$categoryPageAddParams">%factfinder.category_page.add_params%</bind>
             <bind key="$configurationAddParams">%factfinder.configuration.add_params%</bind>
             <bind key="$communicationParameters">%factfinder.communication.parameters.base%</bind>
-            <bind key="$feedPreprocessorEntryRepository" type="service" id="factfinder_feed_preprocessor.repository" />
+            <bind key="$entryRepository" type="service" id="factfinder_feed_preprocessor.repository" />
         </defaults>
 
         <service id="Omikron\FactFinder\Communication\Resource\AdapterFactory" />

--- a/src/Subscriber/FeedPreprocessorEntrySubscriber.php
+++ b/src/Subscriber/FeedPreprocessorEntrySubscriber.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Subscriber;
+
+use Omikron\FactFinder\Shopware6\Events\FeedPreprocessorEntryBeforeCreate;
+use Omikron\FactFinder\Shopware6\Export\Field\CategoryPath;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+
+class FeedPreprocessorEntrySubscriber implements EventSubscriberInterface
+{
+    private CategoryPath $categoryFieldGenerator;
+    private EntityRepositoryInterface $productRepository;
+
+    public function __construct(
+        EntityRepositoryInterface $productRepository,
+        CategoryPath              $categoryPath
+    ) {
+        $this->productRepository      = $productRepository;
+        $this->categoryFieldGenerator = $categoryPath;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [FeedPreprocessorEntryBeforeCreate::class => 'onCreateEntry'];
+    }
+
+    public function onCreateEntry(FeedPreprocessorEntryBeforeCreate $event): void
+    {
+        $entry    = $event->getEntry();
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('productNumber', $entry['productNumber']));
+        $criteria->addAssociation('categories');
+        $criteria->addAssociation('categoriesRo');
+        $product      = $this->productRepository->search($criteria, $event->getContext())->first();
+        $categoryPath = $this->categoryFieldGenerator->getValue($product);
+        $entry['additionalCache'] = ['CategoryPath' => $categoryPath];
+        $event->setEntry($entry);
+    }
+}

--- a/src/Subscriber/FeedPreprocessorEntrySubscriber.php
+++ b/src/Subscriber/FeedPreprocessorEntrySubscriber.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Subscriber;
@@ -6,9 +7,9 @@ namespace Omikron\FactFinder\Shopware6\Subscriber;
 use Omikron\FactFinder\Shopware6\Events\FeedPreprocessorEntryBeforeCreate;
 use Omikron\FactFinder\Shopware6\Export\Field\CategoryPath;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class FeedPreprocessorEntrySubscriber implements EventSubscriberInterface
 {
@@ -17,7 +18,7 @@ class FeedPreprocessorEntrySubscriber implements EventSubscriberInterface
 
     public function __construct(
         EntityRepositoryInterface $productRepository,
-        CategoryPath              $categoryPath
+        CategoryPath $categoryPath
     ) {
         $this->productRepository      = $productRepository;
         $this->categoryFieldGenerator = $categoryPath;
@@ -35,8 +36,8 @@ class FeedPreprocessorEntrySubscriber implements EventSubscriberInterface
         $criteria->addFilter(new EqualsFilter('productNumber', $entry['productNumber']));
         $criteria->addAssociation('categories');
         $criteria->addAssociation('categoriesRo');
-        $product      = $this->productRepository->search($criteria, $event->getContext())->first();
-        $categoryPath = $this->categoryFieldGenerator->getValue($product);
+        $product                  = $this->productRepository->search($criteria, $event->getContext())->first();
+        $categoryPath             = $this->categoryFieldGenerator->getValue($product);
         $entry['additionalCache'] = ['CategoryPath' => $categoryPath];
         $event->setEntry($entry);
     }

--- a/src/Subscriber/ProductIndexerSubscriber.php
+++ b/src/Subscriber/ProductIndexerSubscriber.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Subscriber;
+
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessor;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryPersister;
+use Shopware\Core\Content\Product\Events\ProductIndexerEvent;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NandFilter;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ProductIndexerSubscriber implements EventSubscriberInterface
+{
+    private EntityRepositoryInterface $productRepository;
+    private EntityRepositoryInterface $languageRepository;
+    private FeedPreprocessor $feedPreprocessor;
+    private FeedPreprocessorEntryPersister  $entryPersister;
+
+    public function __construct(
+        EntityRepositoryInterface      $productRepository,
+        EntityRepositoryInterface      $languageRepository,
+        FeedPreprocessor               $feedPreprocessor,
+        FeedPreprocessorEntryPersister $feedPreprocessorEntryPersister
+    ) {
+        $this->productRepository  = $productRepository;
+        $this->languageRepository = $languageRepository;
+        $this->feedPreprocessor   = $feedPreprocessor;
+        $this->entryPersister     = $feedPreprocessorEntryPersister;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [ProductIndexerEvent::class => 'processVariantsToExport'];
+    }
+
+    public function processVariantsToExport(ProductIndexerEvent $event): void
+    {
+        $languages = $this->fetchLanguages();
+        foreach ($languages as $language) {
+            $context  = $this->createLanguageContext($event, $language);
+            $iterator = $this->getProductsIterator($event->getIds(), $context);
+
+            while ($products = $iterator->fetch()) {
+                foreach ($products as $product) {
+                    $this->entryPersister->deleteAllProductEntries($product->getProductNumber(), $context);
+                    $this->feedPreprocessor->setContext($context);
+                    $entries = $this->feedPreprocessor->createEntries($product, $context);
+                    $this->entryPersister->insertProductEntries($entries, $context);
+                }
+            }
+        }
+    }
+
+    private function createLanguageContext(ProductIndexerEvent $event, LanguageEntity $language): Context
+    {
+        return new Context(
+            new SystemSource(),
+            [],
+            Defaults::CURRENCY,
+            array_filter([$language->getId(), $language->getParentId(), Defaults::LANGUAGE_SYSTEM]),
+            $event->getContext()->getVersionId()
+        );
+    }
+
+    private function getProductsIterator(array $productIds, Context $context): RepositoryIterator
+    {
+        $context->setConsiderInheritance(true);
+        $criteria = new Criteria($productIds);
+        $criteria->addAssociation('configuratorGroupConfig');
+        $criteria->addAssociation('children.options.group');
+        return new RepositoryIterator($this->productRepository, $context, $criteria);
+    }
+
+    private function fetchLanguages(): array
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new NandFilter([new EqualsFilter('salesChannelDomains.id', null)]));
+        /** @var LanguageCollection $languages */
+        $languages = $this->languageRepository->search($criteria, Context::createDefaultContext())->getEntities();
+
+        return $languages->getElements();
+    }
+}

--- a/src/Subscriber/ProductIndexerSubscriber.php
+++ b/src/Subscriber/ProductIndexerSubscriber.php
@@ -20,6 +20,9 @@ use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageEntity;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class ProductIndexerSubscriber implements EventSubscriberInterface
 {
     private EntityRepositoryInterface $productRepository;
@@ -32,13 +35,13 @@ class ProductIndexerSubscriber implements EventSubscriberInterface
         EntityRepositoryInterface $productRepository,
         EntityRepositoryInterface $languageRepository,
         FeedPreprocessor $feedPreprocessor,
-        FeedPreprocessorEntryPersister $feedPreprocessorEntryPersister,
+        FeedPreprocessorEntryPersister $entryPersister,
         ExportSettings $exportSettings
     ) {
         $this->productRepository  = $productRepository;
         $this->languageRepository = $languageRepository;
         $this->feedPreprocessor   = $feedPreprocessor;
-        $this->entryPersister     = $feedPreprocessorEntryPersister;
+        $this->entryPersister     = $entryPersister;
         $this->exportSettings     = $exportSettings;
     }
 
@@ -88,6 +91,9 @@ class ProductIndexerSubscriber implements EventSubscriberInterface
         return new RepositoryIterator($this->productRepository, $context, $criteria);
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
     private function fetchLanguages(): array
     {
         $criteria = new Criteria();

--- a/src/Subscriber/ProductIndexerSubscriber.php
+++ b/src/Subscriber/ProductIndexerSubscriber.php
@@ -53,7 +53,6 @@ class ProductIndexerSubscriber implements EventSubscriberInterface
             while ($products = $iterator->fetch()) {
                 foreach ($products as $product) {
                     $this->entryPersister->deleteAllProductEntries($product->getProductNumber(), $context);
-                    $this->feedPreprocessor->setContext($context);
                     $entries = $this->feedPreprocessor->createEntries($product, $context);
                     $this->entryPersister->insertProductEntries($entries, $context);
                 }

--- a/src/Subscriber/ProductIndexerSubscriber.php
+++ b/src/Subscriber/ProductIndexerSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Subscriber;
 
+use Omikron\FactFinder\Shopware6\Config\ExportSettings;
 use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessor;
 use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryPersister;
 use Shopware\Core\Content\Product\Events\ProductIndexerEvent;
@@ -25,17 +26,20 @@ class ProductIndexerSubscriber implements EventSubscriberInterface
     private EntityRepositoryInterface $languageRepository;
     private FeedPreprocessor $feedPreprocessor;
     private FeedPreprocessorEntryPersister  $entryPersister;
+    private ExportSettings $exportSettings;
 
     public function __construct(
         EntityRepositoryInterface      $productRepository,
         EntityRepositoryInterface      $languageRepository,
         FeedPreprocessor               $feedPreprocessor,
-        FeedPreprocessorEntryPersister $feedPreprocessorEntryPersister
+        FeedPreprocessorEntryPersister $feedPreprocessorEntryPersister,
+        ExportSettings                 $exportSettings
     ) {
         $this->productRepository  = $productRepository;
         $this->languageRepository = $languageRepository;
         $this->feedPreprocessor   = $feedPreprocessor;
         $this->entryPersister     = $feedPreprocessorEntryPersister;
+        $this->exportSettings     = $exportSettings;
     }
 
     public static function getSubscribedEvents()
@@ -45,6 +49,10 @@ class ProductIndexerSubscriber implements EventSubscriberInterface
 
     public function processVariantsToExport(ProductIndexerEvent $event): void
     {
+        if ($this->exportSettings->isExportCacheEnable() === false) {
+            return;
+        }
+
         $languages = $this->fetchLanguages();
         foreach ($languages as $language) {
             $context  = $this->createLanguageContext($event, $language);

--- a/src/Subscriber/ProductIndexerSubscriber.php
+++ b/src/Subscriber/ProductIndexerSubscriber.php
@@ -29,11 +29,11 @@ class ProductIndexerSubscriber implements EventSubscriberInterface
     private ExportSettings $exportSettings;
 
     public function __construct(
-        EntityRepositoryInterface      $productRepository,
-        EntityRepositoryInterface      $languageRepository,
-        FeedPreprocessor               $feedPreprocessor,
+        EntityRepositoryInterface $productRepository,
+        EntityRepositoryInterface $languageRepository,
+        FeedPreprocessor $feedPreprocessor,
         FeedPreprocessorEntryPersister $feedPreprocessorEntryPersister,
-        ExportSettings                 $exportSettings
+        ExportSettings $exportSettings
     ) {
         $this->productRepository  = $productRepository;
         $this->languageRepository = $languageRepository;

--- a/src/TestUtil/ExportProductMockFactory.php
+++ b/src/TestUtil/ExportProductMockFactory.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\TestUtil;
 
 use ArrayIterator;
-use Shopware\Core\Content\Product\ProductEntity;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
+use Shopware\Core\Content\Product\ProductEntity;
 
 class ExportProductMockFactory
 {
@@ -19,9 +19,9 @@ class ExportProductMockFactory
 
     public function create(ProductEntity $product, $data = []): ExportProductEntity
     {
-        $productFields = isset($data['productFields']) ? new ArrayIterator($data['productFields']) : new ArrayIterator();
+        $productFields       = isset($data['productFields']) ? new ArrayIterator($data['productFields']) : new ArrayIterator();
         $cachedProductFields = isset($data['cachedProductFields']) ? new ArrayIterator($data['cachedProductFields']) : new ArrayIterator();
-        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), $productFields, $cachedProductFields);
+        $entity              = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), $productFields, $cachedProductFields);
         $entity->setFilterAttributes($data['filterAttributes'] ?? '');
         $entity->setAdditionalCache(isset($data['additionalCache']) ? new ArrayIterator($data['additionalCache']) : new ArrayIterator());
 

--- a/src/TestUtil/ExportProductMockFactory.php
+++ b/src/TestUtil/ExportProductMockFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use Shopware\Core\Content\Product\ProductEntity;
+use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
+
+class ExportProductMockFactory
+{
+    private SalesChannelProductMockFactory $salesChannelProductMockFactory;
+
+    public function __construct()
+    {
+        $this->salesChannelProductMockFactory = new SalesChannelProductMockFactory();
+    }
+
+    public function create(ProductEntity $product, $data = []): ExportProductEntity
+    {
+        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), []);
+        $entity->setFilterAttributes($data['filterAttributes'] ?? '');
+
+        return $entity;
+    }
+}

--- a/src/TestUtil/ExportProductMockFactory.php
+++ b/src/TestUtil/ExportProductMockFactory.php
@@ -18,7 +18,7 @@ class ExportProductMockFactory
 
     public function create(ProductEntity $product, $data = []): ExportProductEntity
     {
-        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), []);
+        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), [], []);
         $entity->setFilterAttributes($data['filterAttributes'] ?? '');
 
         return $entity;

--- a/src/TestUtil/ExportProductMockFactory.php
+++ b/src/TestUtil/ExportProductMockFactory.php
@@ -10,18 +10,18 @@ use Shopware\Core\Content\Product\ProductEntity;
 
 class ExportProductMockFactory
 {
-    private SalesChannelProductMockFactory $salesChannelProductMockFactory;
+    private SalesChannelProductMockFactory $productMockFactory;
 
     public function __construct()
     {
-        $this->salesChannelProductMockFactory = new SalesChannelProductMockFactory();
+        $this->productMockFactory = new SalesChannelProductMockFactory();
     }
 
     public function create(ProductEntity $product, $data = []): ExportProductEntity
     {
         $productFields       = isset($data['productFields']) ? new ArrayIterator($data['productFields']) : new ArrayIterator();
         $cachedProductFields = isset($data['cachedProductFields']) ? new ArrayIterator($data['cachedProductFields']) : new ArrayIterator();
-        $entity              = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), $productFields, $cachedProductFields);
+        $entity              = new ExportProductEntity($this->productMockFactory->create($product), $productFields, $cachedProductFields);
         $entity->setFilterAttributes($data['filterAttributes'] ?? '');
         $entity->setAdditionalCache(isset($data['additionalCache']) ? new ArrayIterator($data['additionalCache']) : new ArrayIterator());
 

--- a/src/TestUtil/ExportProductMockFactory.php
+++ b/src/TestUtil/ExportProductMockFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\TestUtil;
 
+use ArrayIterator;
 use Shopware\Core\Content\Product\ProductEntity;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
 
@@ -18,8 +19,11 @@ class ExportProductMockFactory
 
     public function create(ProductEntity $product, $data = []): ExportProductEntity
     {
-        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), new \ArrayIterator(), new \ArrayIterator());
+        $productFields = isset($data['productFields']) ? new ArrayIterator($data['productFields']) : new ArrayIterator();
+        $cachedProductFields = isset($data['cachedProductFields']) ? new ArrayIterator($data['cachedProductFields']) : new ArrayIterator();
+        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), $productFields, $cachedProductFields);
         $entity->setFilterAttributes($data['filterAttributes'] ?? '');
+        $entity->setAdditionalCache(isset($data['additionalCache']) ? new ArrayIterator($data['additionalCache']) : new ArrayIterator());
 
         return $entity;
     }

--- a/src/TestUtil/ExportProductMockFactory.php
+++ b/src/TestUtil/ExportProductMockFactory.php
@@ -18,7 +18,7 @@ class ExportProductMockFactory
 
     public function create(ProductEntity $product, $data = []): ExportProductEntity
     {
-        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), [], new \ArrayIterator());
+        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), new \ArrayIterator(), new \ArrayIterator());
         $entity->setFilterAttributes($data['filterAttributes'] ?? '');
 
         return $entity;

--- a/src/TestUtil/ExportProductMockFactory.php
+++ b/src/TestUtil/ExportProductMockFactory.php
@@ -18,7 +18,7 @@ class ExportProductMockFactory
 
     public function create(ProductEntity $product, $data = []): ExportProductEntity
     {
-        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), [], []);
+        $entity = new ExportProductEntity($this->salesChannelProductMockFactory->create($product), [], new \ArrayIterator());
         $entity->setFilterAttributes($data['filterAttributes'] ?? '');
 
         return $entity;

--- a/src/TestUtil/FeedPreprocessorEntryMockFactory.php
+++ b/src/TestUtil/FeedPreprocessorEntryMockFactory.php
@@ -19,6 +19,7 @@ class FeedPreprocessorEntryMockFactory
         $feedPreprocessorEntry->setParentProductNumber($product->getParent()->getProductNumber());
         $feedPreprocessorEntry->setVariationKey($data['variationKey'] ?? '');
         $feedPreprocessorEntry->setFilterAttributes($data['filterAttributes'] ?? '');
+        $feedPreprocessorEntry->setCustomFields($data['customFields'] ?? '');
         $feedPreprocessorEntry->setLanguageId($data['languageId'] ?? (new Context(new SystemSource()))->getLanguageId());
         $feedPreprocessorEntry->setAdditionalCache($data['additionalCache'] ?? []);
 

--- a/src/TestUtil/FeedPreprocessorEntryMockFactory.php
+++ b/src/TestUtil/FeedPreprocessorEntryMockFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+
+class FeedPreprocessorEntryMockFactory
+{
+    public function create(ProductEntity $product, array $data = []): FeedPreprocessorEntry
+    {
+        $feedPreprocessorEntry = new FeedPreprocessorEntry();
+        $feedPreprocessorEntry->setId($product->getId());
+        $feedPreprocessorEntry->setProductNumber($product->getProductNumber());
+        $feedPreprocessorEntry->setParentProductNumber($product->getParent()->getProductNumber());
+        $feedPreprocessorEntry->setVariationKey($data['variationKey'] ?? '');
+        $feedPreprocessorEntry->setFilterAttributes($data['filterAttributes'] ?? '');
+        $feedPreprocessorEntry->setLanguageId($data['languageId'] ?? (new Context(new SystemSource()))->getLanguageId());
+        $feedPreprocessorEntry->setAdditionalCache($data['additionalCache'] ?? []);
+
+        return $feedPreprocessorEntry;
+    }
+}

--- a/src/TestUtil/ProductMockFactory.php
+++ b/src/TestUtil/ProductMockFactory.php
@@ -18,7 +18,7 @@ class ProductMockFactory
             [
                 [md5('size'), 'false'],
                 [md5('color'), 'true'],
-                [md5('material'), 'true']
+                [md5('material'), 'true'],
             ]
         ));
 
@@ -27,15 +27,16 @@ class ProductMockFactory
 
     /**
      * $groupConfig in format
-     *  [[groupId, true|false]]
+     *  [[groupId, true|false]].
      *
      * @param array $groupsConfig
+     *
      * @return array
      */
     public static function getGroupConfigurationConfig(array $groupsConfig): array
     {
         $row        = '{"id": "%s", "representation": "box", "expressionForListings": %s}';
-        $jsonConfig = array_map(fn(array $groupConfig): array => json_decode(sprintf($row, ...$groupConfig), true), $groupsConfig);
+        $jsonConfig = array_map(fn (array $groupConfig): array => json_decode(sprintf($row, ...$groupConfig), true), $groupsConfig);
 
         return $jsonConfig;
     }

--- a/src/TestUtil/ProductMockFactory.php
+++ b/src/TestUtil/ProductMockFactory.php
@@ -7,6 +7,9 @@ namespace Omikron\FactFinder\Shopware6\TestUtil;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\Uuid\Uuid;
 
+/**
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
 class ProductMockFactory
 {
     public function create(array $data = []): ProductEntity

--- a/src/TestUtil/ProductMockFactory.php
+++ b/src/TestUtil/ProductMockFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class ProductMockFactory
+{
+    public function create(array $data = []): ProductEntity
+    {
+        $productEntity = new ProductEntity();
+        $productEntity->setId($data['id'] ?? Uuid::randomHex());
+        $productEntity->setProductNumber($data['productNumber'] ?? 'SW100');
+        $productEntity->setConfiguratorGroupConfig($data['configuratorGroupConfig'] ?? self::getGroupConfigurationConfig(
+            [
+                [md5('size'), 'false'],
+                [md5('color'), 'true'],
+                [md5('material'), 'true']
+            ]
+        ));
+
+        return $productEntity;
+    }
+
+    /**
+     * $groupConfig in format
+     *  [[groupId, true|false]]
+     *
+     * @param array $groupsConfig
+     * @return array
+     */
+    public static function getGroupConfigurationConfig(array $groupsConfig): array
+    {
+        $row        = '{"id": "%s", "representation": "box", "expressionForListings": %s}';
+        $jsonConfig = array_map(fn(array $groupConfig): array => json_decode(sprintf($row, ...$groupConfig), true), $groupsConfig);
+
+        return $jsonConfig;
+    }
+}

--- a/src/TestUtil/ProductVariantMockFactory.php
+++ b/src/TestUtil/ProductVariantMockFactory.php
@@ -14,6 +14,9 @@ use Shopware\Core\Content\Property\Aggregate\PropertyGroupTranslation\PropertyGr
 use Shopware\Core\Content\Property\PropertyGroupEntity;
 use Shopware\Core\Framework\Uuid\Uuid;
 
+/**
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
 class ProductVariantMockFactory
 {
     public function create(

--- a/src/TestUtil/ProductVariantMockFactory.php
+++ b/src/TestUtil/ProductVariantMockFactory.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslation\PropertyGroupOptionTranslationCollection;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslation\PropertyGroupOptionTranslationEntity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupTranslation\PropertyGroupTranslationCollection;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupTranslation\PropertyGroupTranslationEntity;
+use Shopware\Core\Content\Property\PropertyGroupEntity;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class ProductVariantMockFactory
+{
+    public function create(
+        ProductEntity $parent,
+        array $data = []
+    ): ProductEntity {
+        $variant = new ProductEntity();
+        $size = $data['size'] ?? 'S';
+        $color = $data['color'] ?? 'red';
+        $material = $data['material'] ?? 'cotton';
+        $variant->setParent($parent);
+        $variant->setProductNumber($data['productNumber'] ?? 'SW100.1');
+        $variant->setId($data['id'] ?? Uuid::randomHex());
+        $variant->setParentId($parent->getId());
+        $variant->setOptions($data['options'] ?? self::createPropertyGroupOptionCollection(
+            [
+                [md5('size'), md5($size), 'size', $size],
+                [md5('color'), md5($color), 'color', $color],
+                [md5('material'), md5($material), 'material', $material],
+            ]
+        ));
+        $variant->setCustomFields($data['customFields'] ?? []);
+
+        return $variant;
+    }
+
+    /**
+     * $optionsConfig in format
+     *  [['groupId','optionId', 'groupName', 'optionName']]
+     *
+     * @param array $optionsConfig
+     * @return PropertyGroupOptionCollection
+     */
+    public static function createPropertyGroupOptionCollection(array $optionsConfig): PropertyGroupOptionCollection
+    {
+        $options    = array_reduce($optionsConfig, function (array $carriedOptions, array $optionConfig): array {
+            list($groupId, $optionId, $groupName, $optionName) = $optionConfig;
+            $group = new PropertyGroupEntity();
+            $group->setId($groupId);
+
+            $groupTranslation = new PropertyGroupTranslationEntity();
+            $groupTranslation->setPropertyGroupId(md5($groupId));
+            $groupTranslation->setName($groupName);
+            $groupTranslation->setUniqueIdentifier(Uuid::randomHex());
+
+            $group->setTranslations(new PropertyGroupTranslationCollection([md5($groupName) => $groupTranslation]));
+            $group->addTranslated('name', $groupName);
+
+            $option = new PropertyGroupOptionEntity();
+            $option->setId($optionId);
+
+            $optionTranslation = new PropertyGroupOptionTranslationEntity();
+            $optionTranslation->setPropertyGroupOptionId(md5($optionName));
+            $optionTranslation->setName($optionName);
+            $optionTranslation->setUniqueIdentifier(Uuid::randomHex());
+
+            $option->setTranslations(new PropertyGroupOptionTranslationCollection([md5($optionName) => $optionTranslation]));
+            $option->addTranslated('name', $optionName);
+            $option->setGroupId($groupId);
+            $option->setGroup($group);
+
+            return array_merge($carriedOptions, [$optionId => $option]);
+        }, []);
+
+        return new PropertyGroupOptionCollection($options);
+    }
+}

--- a/src/TestUtil/ProductVariantMockFactory.php
+++ b/src/TestUtil/ProductVariantMockFactory.php
@@ -20,9 +20,9 @@ class ProductVariantMockFactory
         ProductEntity $parent,
         array $data = []
     ): ProductEntity {
-        $variant = new ProductEntity();
-        $size = $data['size'] ?? 'S';
-        $color = $data['color'] ?? 'red';
+        $variant  = new ProductEntity();
+        $size     = $data['size'] ?? 'S';
+        $color    = $data['color'] ?? 'red';
         $material = $data['material'] ?? 'cotton';
         $variant->setParent($parent);
         $variant->setProductNumber($data['productNumber'] ?? 'SW100.1');
@@ -41,9 +41,10 @@ class ProductVariantMockFactory
 
     /**
      * $optionsConfig in format
-     *  [['groupId','optionId', 'groupName', 'optionName']]
+     *  [['groupId','optionId', 'groupName', 'optionName']].
      *
      * @param array $optionsConfig
+     *
      * @return PropertyGroupOptionCollection
      */
     public static function createPropertyGroupOptionCollection(array $optionsConfig): PropertyGroupOptionCollection

--- a/src/TestUtil/ProductVariantMockFactory.php
+++ b/src/TestUtil/ProductVariantMockFactory.php
@@ -35,7 +35,6 @@ class ProductVariantMockFactory
                 [md5('material'), md5($material), 'material', $material],
             ]
         ));
-        $variant->setCustomFields($data['customFields'] ?? []);
 
         return $variant;
     }

--- a/src/TestUtil/SalesChannelProductMockFactory.php
+++ b/src/TestUtil/SalesChannelProductMockFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\TestUtil;
 
-use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 
 class SalesChannelProductMockFactory
 {

--- a/src/TestUtil/SalesChannelProductMockFactory.php
+++ b/src/TestUtil/SalesChannelProductMockFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Content\Product\ProductEntity;
+
+class SalesChannelProductMockFactory
+{
+    public function create(ProductEntity $product): SalesChannelProductEntity
+    {
+        $entity = new SalesChannelProductEntity();
+        $entity->setId($product->getId());
+        $entity->setProductNumber($product->getProductNumber());
+        $entity->setParent($product->getParent());
+        $entity->setParentId($product->getParentId());
+        $entity->setOptions($product->getOptions());
+
+        return $entity;
+    }
+}


### PR DESCRIPTION
- Description: 
Adds cache mechanism that holds preprocessed product rows inside the database table. Also it takes products Storefront presentation configuration into consideration

- Tested with Shopware6 editions/versions: 
6.4.10
- Tested with PHP versions: 
7.4, 8.1