### PR TITLE
FFWEB-2607: decorate CookieProviderInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Change
+- extended the cookie consent manager with cookies added in release [v3.3.2](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/releases/tag/v3.3.2)
+
 ## [v3.3.2] - 2022.10.24
 ### Change
 - Upgrade Web Components version to v4.2.2

--- a/spec/Subscriber/BeforeSendResponseEventSubscriberSpec.php
+++ b/spec/Subscriber/BeforeSendResponseEventSubscriberSpec.php
@@ -142,11 +142,11 @@ class BeforeSendResponseEventSubscriberSpec extends ObjectBehavior
         $this->session->get('ff_has_just_logged_in', Argument::any())->willReturn(true);
         $this->headers->setCookie(Cookie::create('ff_has_just_logged_in')
             ->withValue('1')
-            ->withExpires((new DateTime())->modify('+1 hour')->getTimestamp())
+            ->withExpires((new DateTime())->modify('+1 day')->getTimestamp())
             ->withHttpOnly(false))->shouldBeCalled();
         $this->headers->setCookie(Cookie::create('ff_user_id')
             ->withValue('test_id_1')
-            ->withExpires((new DateTime())->modify('+1 hour')->getTimestamp())
+            ->withExpires((new DateTime())->modify('+1 day')->getTimestamp())
             ->withHttpOnly(false))->shouldBeCalled();
         $this->session->set('ff_has_just_logged_in', false)->shouldBeCalled();
 
@@ -160,7 +160,7 @@ class BeforeSendResponseEventSubscriberSpec extends ObjectBehavior
         $this->session->get('ff_has_just_logged_out', Argument::any())->willReturn(true);
         $this->headers->setCookie(Cookie::create('ff_has_just_logged_out')
             ->withValue('1')
-            ->withExpires((new DateTime())->modify('+1 hour')->getTimestamp())
+            ->withExpires((new DateTime())->modify('+1 day')->getTimestamp())
             ->withHttpOnly(false))->shouldBeCalled();
         $this->headers->clearCookie('ff_user_id')->shouldBeCalled();
         $this->session->set('ff_has_just_logged_out', false)->shouldBeCalled();

--- a/src/Cookie/CookieProvider.php
+++ b/src/Cookie/CookieProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Cookie;
+
+use Omikron\FactFinder\Shopware6\Subscriber\BeforeSendResponseEventSubscriber;
+use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
+
+class CookieProvider implements CookieProviderInterface
+{
+    private const HAS_JUST_LOGGED_IN = [
+        'snippet_name' => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN,
+        'snippet_description' => 'Cookie required for proper working of user login tracking event',
+        'cookie' => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN,
+    ];
+
+    private const HAS_JUST_LOGGED_OUT = [
+        'snippet_name' => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_OUT,
+        'snippet_description' => 'Cookie required for proper working of user login tracking event',
+        'cookie' => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_OUT,
+    ];
+
+    private const USER_ID = [
+        'snippet_name' => BeforeSendResponseEventSubscriber::USER_ID,
+        'snippet_description' => 'Cookie required for proper working of user login tracking event',
+        'cookie' => BeforeSendResponseEventSubscriber::USER_ID,
+    ];
+
+    private CookieProviderInterface $originalService;
+
+    public function __construct(CookieProviderInterface $service)
+    {
+        $this->originalService = $service;
+    }
+
+    public function getCookieGroups(): array
+    {
+        return array_merge(
+            $this->originalService->getCookieGroups(),
+            [
+                self::HAS_JUST_LOGGED_IN,
+                self::HAS_JUST_LOGGED_OUT,
+                self::USER_ID,
+            ]
+        );
+    }
+}

--- a/src/Cookie/CookieProvider.php
+++ b/src/Cookie/CookieProvider.php
@@ -10,21 +10,21 @@ use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 class CookieProvider implements CookieProviderInterface
 {
     private const HAS_JUST_LOGGED_IN = [
-        'snippet_name' => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN,
+        'snippet_name'        => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN,
         'snippet_description' => 'Cookie required for proper working of user login tracking event',
-        'cookie' => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN,
+        'cookie'              => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN,
     ];
 
     private const HAS_JUST_LOGGED_OUT = [
-        'snippet_name' => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_OUT,
+        'snippet_name'        => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_OUT,
         'snippet_description' => 'Cookie required for proper working of user login tracking event',
-        'cookie' => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_OUT,
+        'cookie'              => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_OUT,
     ];
 
     private const USER_ID = [
-        'snippet_name' => BeforeSendResponseEventSubscriber::USER_ID,
+        'snippet_name'        => BeforeSendResponseEventSubscriber::USER_ID,
         'snippet_description' => 'Cookie required for proper working of user login tracking event',
-        'cookie' => BeforeSendResponseEventSubscriber::USER_ID,
+        'cookie'              => BeforeSendResponseEventSubscriber::USER_ID,
     ];
 
     private CookieProviderInterface $originalService;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -119,5 +119,11 @@
         </service>
         <service id="Omikron\FactFinder\Shopware6\Config\Communication" public="true"/>
         <service id="Omikron\FactFinder\Shopware6\Config\FieldRoles" public="true"/>
+
+        <service id="Omikron\FactFinder\Shopware6\Cookie\CookieProvider"
+                 decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
+            <argument type="service"
+                      id="Omikron\FactFinder\Shopware6\Cookie\CookieProvider.inner" />
+        </service>
     </services>
 </container>

--- a/src/Subscriber/BeforeSendResponseEventSubscriber.php
+++ b/src/Subscriber/BeforeSendResponseEventSubscriber.php
@@ -17,7 +17,7 @@ class BeforeSendResponseEventSubscriber implements EventSubscriberInterface
 {
     public const HAS_JUST_LOGGED_IN  = 'ff_has_just_logged_in';
     public const HAS_JUST_LOGGED_OUT = 'ff_has_just_logged_out';
-    private const USER_ID            = 'ff_user_id';
+    public const USER_ID             = 'ff_user_id';
 
     public static function getSubscribedEvents()
     {
@@ -113,7 +113,7 @@ class BeforeSendResponseEventSubscriber implements EventSubscriberInterface
     {
         return Cookie::create($name)
             ->withValue($value)
-            ->withExpires((new DateTime())->modify('+1 hour')->getTimestamp())
+            ->withExpires((new DateTime())->modify('+1 day')->getTimestamp())
             ->withHttpOnly(false);
     }
 


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2607
- Description:
  - extended the cookie consent manager with cookies added in release [v3.3.2](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/releases/tag/v3.3.2)
- Tested with Shopware6 editions/versions: 
  - 6.4.9999999.9999999 Developer Version
- Tested with PHP versions: 
  - 7.4
