### PR TITLE
FFWEB-2620: Remove query parameter from undesirable urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 ### Fix
  - ff-communication
    - add configuration parameters when error page 404
+ - removed `query` parameter from pages different than search result
 
 ## [v3.3.2] - 2022.10.24
 ### Change

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -52,7 +52,7 @@
           }
         }
 
-        if ('{{ page.extensions.factfinder.searchImmediate }}') {
+        if ({{ page.extensions.factfinder.searchImmediate }}) {
           searchImmediate();
         }
       });


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2620
- Description:
  - remove `query` parameter from undesirable urls (not related with FACT-Finder)
- Tested with Shopware6 editions/versions: 
  - 6.4.9999999.9999999 Developer Version
- Tested with PHP versions: 
  - 7.4
