### PR TITLE
FFWEB-2635: Fix problem with missing page in ConfigurationSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Fix problem with missing page in ConfigurationSubscriber
+
 ## [v4.0.3] - 2022.11.29
 ### Add
 - Server-Side Rendering (SSR)

--- a/src/Subscriber/ConfigurationSubscriber.php
+++ b/src/Subscriber/ConfigurationSubscriber.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Subscriber;
 
+use Exception;
 use Omikron\FactFinder\Shopware6\Config\Communication;
 use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Storefront\Event\StorefrontRenderEvent;
 use Shopware\Storefront\Page\GenericPageLoadedEvent;
+use Shopware\Storefront\Page\Page;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ConfigurationSubscriber implements EventSubscriberInterface
@@ -72,17 +74,19 @@ class ConfigurationSubscriber implements EventSubscriberInterface
         }
     }
 
-    private function getPage(ShopwareSalesChannelEvent $event)
+    private function getPage(ShopwareSalesChannelEvent $event): Page
     {
         if (method_exists($event, 'getPage')) {
             return $event->getPage();
         }
 
-        if (isset($event->getParameters()['page'])) {
-            return $event->getParameters()['page'];
+        $parameters = method_exists($event, 'getParameters') && is_array($event->getParameters()) ? $event->getParameters() : [];
+
+        if (isset($parameters['page'])) {
+            return $parameters['page'];
         }
 
-        throw new \Exception(sprintf('Unable to get page from event %s.', get_class($event)));
+        throw new Exception(sprintf('Unable to get page from event %s.', get_class($event)));
     }
 
     private function isSearchImmediate(ShopwareSalesChannelEvent $event): bool


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2635
- Description:
  - Fix problem with missing page in ConfigurationSubscriber
- Tested with Shopware6 editions/versions: 
  - 6.4.9999999.9999999 Developer Version
- Tested with PHP versions: 
  - 7.4