### PR TITLE
FFWEB-2539: Cache preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ final chapter *Exporting Feed* describes how to use provided console command to 
     - [Extending Specific Web Component Template](#extending-specific-web-component-template)
     - [Split ASN on Category Page](#split-asn-on-category-page)
     - [Set custom Field Roles](#set-custom-field-roles)
+    - [Adding custom Export Cache Subscriber](#adding-custom-export-cache-subscriber)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -124,6 +125,10 @@ Without SSR enabled, web crawlers could not have a chance to scan the element re
   default, all custom fields are being exported.
 * Export prices for all Currencies - if disabled, export will contain only one column `Price`. If enabled, all product
   price will be exported in all currency configured for a given sales channel.
+* Enable export cache - if enabled export time will be shorter. Option is connected with `Storefron presentation` - 
+  it means that each `Product listing` will be cached. During building cache `FeedPreprocessorEntryBeforeCreate` 
+  event is triggered, so you can easily hook to it if you would like to cache some additional data. You can find more 
+  details about implementation [here](#adding-custom-export-cache-subscriber).
 
 #### Price Columns Format
 
@@ -565,6 +570,35 @@ Default field roles are defined as array of Symfony Configuration Parameters in 
     </parameter>
 
 In order to override these parameters defined by a module, you have to redefine them in your application `services.xml`. Parameters defined there take precedence over the defaults, defined in the module   
+
+### Adding custom Export Cache Subscriber
+
+```php
+
+use Omikron\FactFinder\Shopware6\Events\FeedPreprocessorEntryBeforeCreate;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class FeedPreprocessorEntryBeforeCreateSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [FeedPreprocessorEntryBeforeCreate::class => 'onCreateEntries'];
+    }
+
+    public function onCreateEntries(FeedPreprocessorEntryBeforeCreate $event)
+    {
+        $entry = $event->getEntry();
+        $entry['additionalCache'] = [
+            'some_data' => 'cache1',
+            'some_data2' => 'cache2',
+        ];
+        $event->setEntry($entry);
+    }
+}
+
+```
+
+
 ## Contribute
 
 We welcome contribution! For more information, click [here](.github/CONTRIBUTING.md)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "3.1",
     "phpmd/phpmd": "^2.9",
-    "phpspec/phpspec": "^6.2"
+    "phpspec/phpspec": "^6.2",
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
+++ b/spec/DataAbstractionLayer/FeedPreprocessorSpec.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Omikron\FactFinder\Shopware6\DataAbstractionLayer;
+
+use Omikron\FactFinder\Shopware6\Export\Field\CustomFields as ExportCustomFields;
+use Omikron\FactFinder\Shopware6\Export\Filter\TextFilter;
+use Omikron\FactFinder\Shopware6\Export\PropertyFormatter;
+use Omikron\FactFinder\Shopware6\TestUtil\ProductMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\ProductVariantMockFactory;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Subject;
+use PHPUnit\Framework\Assert;
+use Prophecy\Argument;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+use PhpSpec\Wrapper\Collaborator;
+
+class FeedPreprocessorSpec extends ObjectBehavior
+{
+    private ProductMockFactory $productMockFactory;
+    private ProductVariantMockFactory $variantMockFactory;
+    private Collaborator $customFields;
+    private Context $context;
+
+    function let(EventDispatcherInterface $eventDispatcher, ExportCustomFields $customFields)
+    {
+        $eventDispatcher->dispatch(Argument::any())->willReturn(new Event());
+        $this->beConstructedWith(new PropertyFormatter(new TextFilter()), $eventDispatcher, $customFields);
+        $this->context = new Context(new SystemSource());
+        $this->productMockFactory = new ProductMockFactory();
+        $this->variantMockFactory = new ProductVariantMockFactory();
+        $this->customFields = $customFields;
+    }
+
+    function it_should_create_only_entries_for_variants_that_should_be_visible()
+    {
+        $productEntity = $this->productMockFactory->create();
+        $variants      = [
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'red', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'red', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.3', 'size' => 'L', 'color' => 'red', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.4', 'size' => 'S', 'color' => 'blue', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.5', 'size' => 'M', 'color' => 'blue', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.6', 'size' => 'L', 'color' => 'blue', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.7', 'size' => 'S', 'color' => 'green', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.8', 'size' => 'M', 'color' => 'green', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.9', 'size' => 'L', 'color' => 'green', 'material' => 'cotton']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.10', 'size' => 'S', 'color' => 'red', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.11', 'size' => 'M', 'color' => 'red', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.12', 'size' => 'L', 'color' => 'red', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.13', 'size' => 'S', 'color' => 'blue', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.14', 'size' => 'M', 'color' => 'blue', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.15', 'size' => 'L', 'color' => 'blue', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.16', 'size' => 'S', 'color' => 'green', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.17', 'size' => 'M', 'color' => 'green', 'material' => 'linen']),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.18', 'size' => 'L', 'color' => 'green', 'material' => 'linen']),
+        ];
+        foreach ($variants as $variant) {
+            $this->customFields->getValue($variant)->willReturn('');
+        }
+
+        $productEntity->setChildren(
+            new ProductCollection(
+                array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array
+                => $carriedVariants + [$product->getId() => $product], [])));
+
+        /** @var Subject $entries */
+        $entries = $this->createEntries($productEntity, $this->context);
+
+        $entries->shouldBeArray();
+        //3 colors * 2 materials = 6 combinations
+        $entries->shouldHaveCount(6);
+
+        $this->validateFilterAttributes(
+            $entries->getWrappedObject(),
+            [
+                'size=S|size=M|size=L|color=red|material=cotton',
+                'size=S|size=M|size=L|color=blue|material=cotton',
+                'size=S|size=M|size=L|color=green|material=cotton',
+                'size=S|size=M|size=L|color=red|material=linen',
+                'size=S|size=M|size=L|color=blue|material=linen',
+                'size=S|size=M|size=L|color=green|material=linen',
+            ]
+        );
+    }
+
+    function it_should_create_entries_with_empty_string_in_custom_fields_when_custom_fields_not_set()
+    {
+        // Given
+        $productEntity = $this->productMockFactory->create();
+        $productEntity->setMainVariantId('SW100');
+        $variant = $this->variantMockFactory->create(
+            $productEntity,
+            ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'red', 'material' => 'cotton', 'customFields' => '']
+        );
+        $productEntity->setChildren(new ProductCollection([$variant]));
+
+        // Expect
+        $this->customFields->getValue($variant)->willReturn('');
+
+        // When
+        $entries = $this->createEntries($productEntity, $this->context);
+        $entries->shouldBeArray();
+        $entries->shouldHaveCount(1);
+
+        // Then
+        Assert::assertEquals('', array_values($entries->getWrappedObject())[0]['customFields']);
+    }
+
+    function it_should_create_entries_with_proper_custom_fields_for_each_display_group()
+    {
+        $this->validateCustomFields(
+            [
+                [md5('size'), 'true'],
+                [md5('color'), 'false'],
+                [md5('material'), 'false']
+            ],
+            [
+                '|pattern=dots|pattern=stripes|shape=rectangle|shape=square|shape=triangle|',
+                '|pattern=dots|pattern=patterned|pattern=stripes|shape=circle|shape=rectangle|shape=triangle|',
+            ]
+        );
+        $this->validateCustomFields(
+            [
+                [md5('size'), 'false'],
+                [md5('color'), 'true'],
+                [md5('material'), 'false']
+            ],
+            [
+                '|pattern=dots|pattern=patterned|pattern=stripes|shape=square|shape=triangle|',
+                '|pattern=dots|pattern=stripes|shape=circle|shape=rectangle|',
+            ]
+        );
+        $this->validateCustomFields(
+            [
+                [md5('size'), 'false'],
+                [md5('color'), 'true'],
+                [md5('material'), 'true']
+            ],
+            [
+                '|pattern=dots|pattern=stripes|shape=triangle|',
+                '|pattern=dots|pattern=patterned|shape=square|shape=triangle|',
+                '|pattern=dots|pattern=stripes|shape=rectangle|',
+                '|pattern=dots|pattern=stripes|shape=circle|shape=rectangle|',
+            ]
+        );
+        $this->validateCustomFields(
+            [
+                [md5('size'), 'true'],
+                [md5('color'), 'true'],
+                [md5('material'), 'true']
+            ],
+            [
+                '|pattern=stripes|shape=triangle|',
+                '|pattern=dots|shape=triangle|',
+                '|pattern=dots|shape=square|',
+                '|pattern=patterned|shape=triangle|',
+                '|pattern=dots|shape=rectangle|',
+                '|pattern=stripes|shape=rectangle|',
+                '|pattern=dots|shape=rectangle|',
+                '|pattern=stripes|shape=circle|',
+            ]
+        );
+    }
+
+    function it_should_export_only_one_entry_if_main_variant_is_selected()
+    {
+        $productEntity = $this->productMockFactory->create();
+        $productEntity->setMainVariantId('SW100');
+        $customFieldsData = [
+            'SW100.1' => ['shape' => 'triangle', 'pattern' => 'stripes'],
+            'SW100.2' => ['shape' => 'rectangle', 'pattern' => 'patterned'],
+            'SW100.3' => ['shape' => 'square', 'pattern' => 'dots'],
+        ];
+
+        $customFieldsValues = [
+            'SW100.1' => '|shape=triangle|pattern=stripes|',
+            'SW100.2' => '|shape=rectangle|pattern=patterned|',
+            'SW100.3' => '|shape=square|pattern=dots|',
+        ];
+
+        $variants = [
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'red', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.1']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'red', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.1']]),
+            $this->variantMockFactory->create($productEntity, ['productNumber' => 'SW100.3', 'size' => 'L', 'color' => 'red', 'material' => 'wool', 'customFields' => $customFieldsData['SW100.1']])
+        ];
+
+        foreach ($variants as $variant) {
+            $this->customFields->getValue($variant)->willReturn($customFieldsValues[$variant->getProductNumber()]);
+        }
+
+        $productEntity->setChildren(
+            new ProductCollection(
+                array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array
+                => $carriedVariants + [$product->getId() => $product], [])));
+
+        /** @var Subject $entries */
+        $entries = $this->createEntries($productEntity, $this->context);
+        $entries->shouldBeArray();
+        //only one entry should be producted
+        $entries->shouldHaveCount(1);
+
+        $this->validateFilterAttributes($entries->getWrappedObject(), [
+            'size=S|size=M|size=L|color=red|material=cotton|material=linen|material=wool'
+        ]);
+
+
+    }
+
+    private function validateFilterAttributes(array $entries, array $filters)
+    {
+        $expected = count($filters);
+        $isContainingFilter = fn(string $filter): callable
+            => fn(array $entry): bool
+                => strpos($entry['filterAttributes'], $filter) !== false;
+
+        $match = array_reduce($filters, fn (int $score, string $filter)
+            => $score + (int) array_filter($entries, $isContainingFilter($filter)), 0);
+
+        Assert::assertEquals($expected, $match);
+    }
+
+    private function validateCustomFields(array $groupConfigurationConfig, array $expectedValues)
+    {
+        // Given
+        $productMockFactory = new ProductMockFactory();
+        $variantMockFactory = new ProductVariantMockFactory();
+        $productEntity = $productMockFactory->create();
+        $productEntity->setConfiguratorGroupConfig(ProductMockFactory::getGroupConfigurationConfig($groupConfigurationConfig));
+        $customFieldsData = [
+            'SW100.1' => ['shape' => 'triangle', 'pattern' => 'stripes'],
+            'SW100.2' => ['shape' => 'triangle', 'pattern' => 'dots'],
+            'SW100.3' => ['shape' => 'square', 'pattern' => 'dots'],
+            'SW100.4' => ['shape' => 'triangle', 'pattern' => 'patterned'],
+            'SW100.5' => ['shape' => 'rectangle', 'pattern' => 'dots'],
+            'SW100.6' => ['shape' => 'rectangle', 'pattern' => 'stripes'],
+            'SW100.7' => ['shape' => 'rectangle', 'pattern' => 'dots'],
+            'SW100.8' => ['shape' => 'circle', 'pattern' => 'stripes'],
+        ];
+        $customFieldsValues = [
+            'SW100.1' => '|shape=triangle|pattern=stripes|',
+            'SW100.2' => '|shape=triangle|pattern=dots|',
+            'SW100.3' => '|shape=square|pattern=dots|',
+            'SW100.4' => '|shape=triangle|pattern=patterned|',
+            'SW100.5' => '|shape=rectangle|pattern=dots|',
+            'SW100.6' => '|shape=rectangle|pattern=stripes|',
+            'SW100.7' => '|shape=rectangle|pattern=dots|',
+            'SW100.8' => '|shape=circle|pattern=stripes|',
+        ];
+        $variants = [
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'green', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.1']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'green', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.2']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.3', 'size' => 'S', 'color' => 'green', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.3']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.4', 'size' => 'M', 'color' => 'green', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.4']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.5', 'size' => 'S', 'color' => 'red', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.5']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.6', 'size' => 'M', 'color' => 'red', 'material' => 'cotton', 'customFields' => $customFieldsData['SW100.6']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.7', 'size' => 'S', 'color' => 'red', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.7']]),
+            $variantMockFactory->create($productEntity, ['productNumber' => 'SW100.8', 'size' => 'M', 'color' => 'red', 'material' => 'linen', 'customFields' => $customFieldsData['SW100.8']]),
+        ];
+        $productEntity->setChildren(new ProductCollection(array_reduce($variants, fn(array $carriedVariants, ProductEntity $product): array => $carriedVariants + [$product->getId() => $product], [])));
+
+        // Expected
+        foreach ($variants as $variant) {
+            $this->customFields->getValue($variant)->willReturn($customFieldsValues[$variant->getProductNumber()]);
+        }
+
+        // When
+        $entries = $this->createEntries($productEntity, $this->context);
+
+        // Then
+        $entries = array_values($entries->getWrappedObject());
+
+        foreach ($expectedValues as $key => $expectedValue) {
+            $gluedCustomFields = explode('|', trim($entries[$key]['customFields'], '|'));
+            sort($gluedCustomFields);
+            $gluedCustomFields = sprintf('|%s|', implode('|', $gluedCustomFields));
+            Assert::assertEquals($expectedValue, $gluedCustomFields);
+        }
+    }
+}

--- a/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
+++ b/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
@@ -134,7 +134,6 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
             $this->exportProductMockFactory->create($variants['SW100.10'], ['filterAttributes' => $filterAttributes['SW100.10'], 'parent' => $productEntity]),
             $this->exportProductMockFactory->create($variants['SW100.13'], ['filterAttributes' => $filterAttributes['SW100.13'], 'parent' => $productEntity]),
             $this->exportProductMockFactory->create($variants['SW100.16'], ['filterAttributes' => $filterAttributes['SW100.16'], 'parent' => $productEntity]),
-            $this->exportProductMockFactory->create($productEntity),
         ];
         $productEntity->setChildren($this->getProductCollection($variants));
 
@@ -211,6 +210,11 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
             $categoryPathField->getName()->willReturn($categoryPathName);
             $fieldsProvider->getFields(SalesChannelProductEntity::class)->willReturn([$categoryPathField]);
         }
+
+        $categoryPathField->getName()->willReturn($categoryPathName);
+        $categoryPathField->getValue($productEntity)->willReturn($categoryPathValue);
+        $categoryPathField->getName()->willReturn($categoryPathName);
+        $fieldsProvider->getFields(ExportProductEntity::class)->willReturn([$categoryPathField]);
 
         // Expect
         $this->feedPreprocessorReader->read($productEntity->getProductNumber(), Argument::any())->willReturn(

--- a/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
+++ b/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
@@ -1,0 +1,436 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Omikron\FactFinder\Shopware6\Export\Data\Factory;
+
+use Omikron\FactFinder\Shopware6\Config\ExportSettings;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessor;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryPersister;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryReader;
+use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
+use Omikron\FactFinder\Shopware6\Export\Data\Factory\FactoryInterface;
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Omikron\FactFinder\Shopware6\Export\Field\CategoryPath;
+use Omikron\FactFinder\Shopware6\Export\FieldsProvider;
+use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
+use Omikron\FactFinder\Shopware6\TestUtil\ExportProductMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\FeedPreprocessorEntryMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\ProductMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\ProductVariantMockFactory;
+use Omikron\FactFinder\Shopware6\TestUtil\SalesChannelProductMockFactory;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Collaborator;
+use PHPUnit\Framework\Assert;
+use Prophecy\Argument;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+class PreprocessedProductEntityFactorySpec extends ObjectBehavior
+{
+    private ProductMockFactory $productMockFactory;
+    private ProductVariantMockFactory $variantMockFactory;
+    private FeedPreprocessorEntryMockFactory $feedPreprocessorEntryMockFactory;
+    private ExportProductMockFactory $exportProductMockFactory;
+    private SalesChannelProductMockFactory $salesChannelProductMockFactory;
+    private Collaborator $exportSettings;
+    private Collaborator $decoratedFactory;
+    private Collaborator $feedPreprocessorReader;
+    private Collaborator $salesChannelService;
+    private Collaborator $feedPreprocessor;
+    private \Traversable $cachedFields;
+
+    function let(
+        SalesChannelContext $salesChannelContext,
+        Context $context,
+        SalesChannelService $salesChannelService,
+        FactoryInterface $decoratedFactory,
+        FeedPreprocessorEntryReader $feedPreprocessorReader,
+        ExportSettings $exportSettings,
+        FeedPreprocessorEntryPersister $entryPersister,
+        FeedPreprocessor $feedPreprocessor
+    ) {
+        $salesChannelContext->getContext()->willReturn($context);
+        $salesChannelContext->getLanguageId()->willReturn('');
+        $salesChannelService->getSalesChannelContext()->willReturn($salesChannelContext);
+        $this->productMockFactory = new ProductMockFactory();
+        $this->variantMockFactory = new ProductVariantMockFactory();
+        $this->feedPreprocessorEntryMockFactory = new FeedPreprocessorEntryMockFactory();
+        $this->exportProductMockFactory = new ExportProductMockFactory();
+        $this->salesChannelProductMockFactory = new SalesChannelProductMockFactory();
+        $this->feedPreprocessorReader = $feedPreprocessorReader;
+        $this->decoratedFactory = $decoratedFactory;
+        $this->cachedFields = new \ArrayIterator();
+        $exportSettings->isExportCacheEnable()->willReturn(true);
+        $this->exportSettings = $exportSettings;
+        $this->salesChannelService = $salesChannelService;
+        $this->feedPreprocessor = $feedPreprocessor;
+        $this->beConstructedWith(
+            $this->decoratedFactory,
+            $this->salesChannelService,
+            new FieldsProvider(new \ArrayIterator()),
+            $this->exportSettings,
+            $this->feedPreprocessorReader,
+            $entryPersister,
+            $this->feedPreprocessor,
+            $this->cachedFields
+        );
+    }
+
+    public function it_should_handle_entities_without_cache_using_fallback_from_decorated_factory(): void
+    {
+        // Given
+        $productEntity = $this->productMockFactory->create();
+
+        // Expect
+        $this->feedPreprocessorReader->read($productEntity->getProductNumber(), Argument::any())->willReturn([]);
+        $this->feedPreprocessor->createEntries($productEntity, Argument::any())->willReturn(['fallback_data']);
+        $this->decoratedFactory->createEntities($productEntity, Argument::any())->willYield(['fallback_data']);
+
+        // When
+        $this->createEntities($productEntity)->shouldYield(['fallback_data']);
+    }
+
+    public function it_should_create_entities_for_variants_that_should_be_visible(): void
+    {
+        // Given
+        $productEntity = $this->productMockFactory->create();
+        $variantsData = [
+            'SW100.1' => ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'red', 'material' => 'cotton'],
+            'SW100.2' => ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'red', 'material' => 'cotton'],
+            'SW100.3' => ['productNumber' => 'SW100.3', 'size' => 'L', 'color' => 'red', 'material' => 'cotton'],
+            'SW100.4' => ['productNumber' => 'SW100.4', 'size' => 'S', 'color' => 'blue', 'material' => 'cotton'],
+            'SW100.5' => ['productNumber' => 'SW100.5', 'size' => 'M', 'color' => 'blue', 'material' => 'cotton'],
+            'SW100.6' => ['productNumber' => 'SW100.6', 'size' => 'L', 'color' => 'blue', 'material' => 'cotton'],
+            'SW100.7' => ['productNumber' => 'SW100.7', 'size' => 'S', 'color' => 'green', 'material' => 'cotton'],
+            'SW100.8' => ['productNumber' => 'SW100.8', 'size' => 'M', 'color' => 'green', 'material' => 'cotton'],
+            'SW100.9' => ['productNumber' => 'SW100.9', 'size' => 'L', 'color' => 'green', 'material' => 'cotton'],
+            'SW100.10' => ['productNumber' => 'SW100.10', 'size' => 'S', 'color' => 'red', 'material' => 'linen'],
+            'SW100.11' => ['productNumber' => 'SW100.11', 'size' => 'M', 'color' => 'red', 'material' => 'linen'],
+            'SW100.12' => ['productNumber' => 'SW100.12', 'size' => 'L', 'color' => 'red', 'material' => 'linen'],
+            'SW100.13' => ['productNumber' => 'SW100.13', 'size' => 'S', 'color' => 'blue', 'material' => 'linen'],
+            'SW100.14' => ['productNumber' => 'SW100.14', 'size' => 'M', 'color' => 'blue', 'material' => 'linen'],
+            'SW100.15' => ['productNumber' => 'SW100.15', 'size' => 'L', 'color' => 'blue', 'material' => 'linen'],
+            'SW100.16' => ['productNumber' => 'SW100.16', 'size' => 'S', 'color' => 'green', 'material' => 'linen'],
+            'SW100.17' => ['productNumber' => 'SW100.17', 'size' => 'M', 'color' => 'green', 'material' => 'linen'],
+            'SW100.18' => ['productNumber' => 'SW100.18', 'size' => 'L', 'color' => 'green', 'material' => 'linen'],
+        ];
+        $variants = array_map(fn (array $variantData) => $this->variantMockFactory->create($productEntity, $variantData), $variantsData);
+        $filterAttributes = [
+            'SW100.1' => 'size=S|size=M|size=L|color=red|material=cotton',
+            'SW100.5' => 'size=S|size=M|size=L|color=blue|material=cotton',
+            'SW100.7' => 'size=S|size=M|size=L|color=green|material=cotton',
+            'SW100.10' => 'size=S|size=M|size=L|color=red|material=linen',
+            'SW100.13' => 'size=S|size=M|size=L|color=blue|material=linen',
+            'SW100.16' => 'size=S|size=M|size=L|color=green|material=linen',
+        ];
+        $expectedVariants = [
+            $this->exportProductMockFactory->create($variants['SW100.1'], ['filterAttributes' => $filterAttributes['SW100.1']]),
+            $this->exportProductMockFactory->create($variants['SW100.5'], ['filterAttributes' => $filterAttributes['SW100.5']]),
+            $this->exportProductMockFactory->create($variants['SW100.7'], ['filterAttributes' => $filterAttributes['SW100.7']]),
+            $this->exportProductMockFactory->create($variants['SW100.10'], ['filterAttributes' => $filterAttributes['SW100.10']]),
+            $this->exportProductMockFactory->create($variants['SW100.13'], ['filterAttributes' => $filterAttributes['SW100.13']]),
+            $this->exportProductMockFactory->create($variants['SW100.16'], ['filterAttributes' => $filterAttributes['SW100.16']]),
+        ];
+        $productEntity->setChildren($this->getProductCollection($variants));
+
+        // Expect
+        $this->feedPreprocessorReader->read($productEntity->getProductNumber(), Argument::any())->willReturn($this->getFeedPreprocessorEntries($productEntity, [
+            $variantsData['SW100.1'] + ['filterAttributes' => $filterAttributes['SW100.1']],
+            $variantsData['SW100.5'] + ['filterAttributes' => $filterAttributes['SW100.5']],
+            $variantsData['SW100.7'] + ['filterAttributes' => $filterAttributes['SW100.7']],
+            $variantsData['SW100.10'] + ['filterAttributes' => $filterAttributes['SW100.10']],
+            $variantsData['SW100.13'] + ['filterAttributes' => $filterAttributes['SW100.13']],
+            $variantsData['SW100.16'] + ['filterAttributes' => $filterAttributes['SW100.16']],
+        ]));
+
+        // When
+        $exportedProducts = iterator_to_array($this->createEntities($productEntity)->getWrappedObject());
+
+        // Then
+        Assert::assertEquals(
+            array_values(array_map(fn(ExportProductEntity $variant) => $variant->toArray(), $expectedVariants)),
+            array_values(array_map(fn (ExportProductEntity $product) => $product->toArray(), $exportedProducts))
+        );
+    }
+
+    public function it_should_create_entities_with_cached_category_path(CategoryPath $categoryPathField, FieldsProvider $fieldsProvider)
+    {
+        // Given
+        $categoryPathName = 'CategoryPath';
+        $categoryPathValue = 'Sports/Books%2C+Clothing+%26+Games/Movies%2C+Electronics+%26+Clothing';
+        $this->beConstructedWith($this->decoratedFactory, $this->salesChannelService, $fieldsProvider, $this->exportSettings, $this->feedPreprocessorReader, $this->cachedFields);
+
+        $productEntity = $this->productMockFactory->create();
+        $variantsData = [
+            'SW100.1' => ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'red', 'material' => 'cotton'],
+            'SW100.2' => ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'blue', 'material' => 'cotton'],
+        ];
+        $variants = array_map(fn (array $variantData) => $this->variantMockFactory->create($productEntity, $variantData), $variantsData);
+        $filterAttributes = [
+            'SW100.1' => 'size=S|size=M|color=red|material=cotton',
+            'SW100.2' => 'size=S|size=M|color=blue|material=cotton',
+        ];
+        $expectedVariants = array_map(function(array $expectedVariantData) use ($filterAttributes, $categoryPathField, $variants, $categoryPathName, $categoryPathValue): ExportProductEntity {
+            $productNumber = $expectedVariantData['productNumber'];
+            $product = $variants[$productNumber];
+            $categoryPathField->getName()->willReturn($categoryPathName);
+            $categoryPathField->getValue($product)->willReturn($categoryPathValue);
+
+            return $this->exportProductMockFactory->create(
+                $product,
+                [
+                    'filterAttributes' => $filterAttributes[$productNumber],
+                    'additionalCache' => [$categoryPathName => $categoryPathValue],
+                    'productFields' => [$categoryPathField->getWrappedObject()],
+                ]
+            );
+        }, $variantsData);
+        $productEntity->setChildren($this->getProductCollection($variants));
+
+        foreach ($variantsData as $variantData) {
+            $productNumber = $variantData['productNumber'];
+            $product = $variants[$productNumber];
+            $categoryPathField->getName()->willReturn($categoryPathName);
+            $fieldsProvider->getFields(SalesChannelProductEntity::class)->willReturn([$categoryPathField]);
+        }
+
+        // Expect
+        $this->feedPreprocessorReader->read($productEntity->getProductNumber(), Argument::any())->willReturn(
+            $this->getFeedPreprocessorEntries(
+                $productEntity,
+                [
+                    $variantsData['SW100.1'] + ['filterAttributes' => $filterAttributes['SW100.1'], 'additionalCache' => ['CategoryPath' => 'Sports/Books%2C+Clothing+%26+Games/Movies%2C+Electronics+%26+Clothing']],
+                    $variantsData['SW100.2'] + ['filterAttributes' => $filterAttributes['SW100.2'], 'additionalCache' => ['CategoryPath' => 'Sports/Books%2C+Clothing+%26+Games/Movies%2C+Electronics+%26+Clothing']],
+                ]
+            )
+        );
+
+        // When
+        $exportedProducts = iterator_to_array($this->createEntities($productEntity)->getWrappedObject());
+
+        // Then
+        Assert::assertEquals(
+            array_values(array_map(fn(ExportProductEntity $variant) => $variant->toArray(), $expectedVariants)),
+            array_values(array_map(fn (ExportProductEntity $product) => $product->toArray(), $exportedProducts))
+        );
+    }
+
+    public function it_should_create_entities_with_proper_custom_fields_for_each_display_group()
+    {
+        $this->validateExportedCustomFields(
+            [
+                [md5('size'), 'true'],
+                [md5('color'), 'false'],
+                [md5('material'), 'false']
+            ],
+            [
+                'SW100.1' => [
+                    'filterAttributes' => 'material=cotton|material=linen|color=red|color=green|size=S',
+                    'customFields' => '|shape=rectangle|pattern=dots|shape=square|shape=triangle|pattern=stripes|',
+                ],
+                'SW100.8' => [
+                    'filterAttributes' => 'material=cotton|material=linen|color=red|color=green|size=M',
+                    'customFields' => '|shape=triangle|pattern=patterned|pattern=dots|shape=rectangle|pattern=stripes|shape=circle|',
+                ],
+            ],
+            [
+                '|pattern=dots|pattern=stripes|shape=rectangle|shape=square|shape=triangle|',
+                '|pattern=dots|pattern=patterned|pattern=stripes|shape=circle|shape=rectangle|shape=triangle|',
+            ]
+        );
+        $this->validateExportedCustomFields(
+            [
+                [md5('size'), 'false'],
+                [md5('color'), 'true'],
+                [md5('material'), 'false']
+            ],
+            [
+                'SW100.1' => [
+                    'filterAttributes' => 'size=S|size=M|material=cotton|material=linen|color=green',
+                    'customFields' => '|shape=triangle|pattern=patterned|pattern=dots|shape=square|pattern=stripes|'
+                ],
+                'SW100.8' => [
+                    'filterAttributes' => 'size=S|size=M|material=cotton|material=linen|color=red',
+                    'customFields' => '|shape=rectangle|pattern=dots|pattern=stripes|shape=circle|'
+                ],
+            ],
+            [
+                '|pattern=dots|pattern=patterned|pattern=stripes|shape=square|shape=triangle|',
+                '|pattern=dots|pattern=stripes|shape=circle|shape=rectangle|',
+            ]
+        );
+        $this->validateExportedCustomFields(
+            [
+                [md5('size'), 'false'],
+                [md5('color'), 'true'],
+                [md5('material'), 'true']
+            ],
+            [
+                'SW100.1' => [
+                    'filterAttributes' => 'size=S|size=M|material=cotton|color=green',
+                    'customFields' => '|shape=triangle|pattern=dots|pattern=stripes|',
+                ],
+                'SW100.3' => [
+                    'filterAttributes' => 'size=S|size=M|color=green|material=linen',
+                    'customFields' => '|shape=triangle|pattern=patterned|shape=square|pattern=dots|',
+                ],
+                'SW100.6' => [
+                    'filterAttributes' => 'size=S|size=M|material=cotton|color=red',
+                    'customFields' => '|shape=rectangle|pattern=dots|pattern=stripes|',
+                ],
+                'SW100.8' => [
+                    'filterAttributes' => 'size=S|size=M|color=red|material=linen',
+                    'customFields' => '|shape=rectangle|pattern=dots|shape=circle|pattern=stripes|',
+                ],
+            ],
+            [
+                '|pattern=dots|pattern=stripes|shape=triangle|',
+                '|pattern=dots|pattern=patterned|shape=square|shape=triangle|',
+                '|pattern=dots|pattern=stripes|shape=rectangle|',
+                '|pattern=dots|pattern=stripes|shape=circle|shape=rectangle|',
+            ]
+        );
+        $this->validateExportedCustomFields(
+            [
+                [md5('size'), 'true'],
+                [md5('color'), 'true'],
+                [md5('material'), 'true']
+            ],
+            [
+                'SW100.1' => [
+                    'filterAttributes' => '|size=S|material=cotton|color=green',
+                    'customFields' => '|shape=triangle|pattern=stripes|',
+                ],
+                'SW100.2' => [
+                    'filterAttributes' => '|material=cotton|color=green|size=M',
+                    'customFields' => '|shape=triangle|pattern=dots|',
+                ],
+                'SW100.3' => [
+                    'filterAttributes' => '|size=S|color=green|material=linen',
+                    'customFields' => '|shape=square|pattern=dots|',
+                ],
+                'SW100.4' => [
+                    'filterAttributes' => '|color=green|size=M|material=linen',
+                    'customFields' => '|shape=triangle|pattern=patterned|',
+                ],
+                'SW100.5' => [
+                    'filterAttributes' => '|size=S|material=cotton|color=red',
+                    'customFields' => '|shape=rectangle|pattern=dots|',
+                ],
+                'SW100.6' => [
+                    'filterAttributes' => '|material=cotton|color=red|size=M',
+                    'customFields' => '|shape=rectangle|pattern=stripes|',
+                ],
+                'SW100.7' => [
+                    'filterAttributes' => '|size=S|color=red|material=linen',
+                    'customFields' => '|shape=rectangle|pattern=dots|',
+                ],
+                'SW100.8' => [
+                    'filterAttributes' => '|color=red|size=M|material=linen',
+                    'customFields' => '|shape=circle|pattern=stripes|',
+                ],
+            ],
+            [
+                '|pattern=stripes|shape=triangle|',
+                '|pattern=dots|shape=triangle|',
+                '|pattern=dots|shape=square|',
+                '|pattern=patterned|shape=triangle|',
+                '|pattern=dots|shape=rectangle|',
+                '|pattern=stripes|shape=rectangle|',
+                '|pattern=dots|shape=rectangle|',
+                '|pattern=stripes|shape=circle|',
+            ]
+        );
+    }
+
+    private function validateExportedCustomFields(
+        array $groupConfigurationConfig,
+        array $feedPreprocessorReaderData,
+        array $expectedValues
+    ): void {
+        // Given
+        $productEntity = $this->productMockFactory->create();
+        $productEntity->setConfiguratorGroupConfig(ProductMockFactory::getGroupConfigurationConfig($groupConfigurationConfig));
+        $customFieldsData = [
+            'SW100.1' => ['shape' => 'triangle', 'pattern' => 'stripes'],
+            'SW100.2' => ['shape' => 'triangle', 'pattern' => 'dots'],
+            'SW100.3' => ['shape' => 'square', 'pattern' => 'dots'],
+            'SW100.4' => ['shape' => 'triangle', 'pattern' => 'patterned'],
+            'SW100.5' => ['shape' => 'rectangle', 'pattern' => 'dots'],
+            'SW100.6' => ['shape' => 'rectangle', 'pattern' => 'stripes'],
+            'SW100.7' => ['shape' => 'rectangle', 'pattern' => 'dots'],
+            'SW100.8' => ['shape' => 'circle', 'pattern' => 'stripes'],
+        ];
+        $variantsData = [
+            'SW100.1' => ['productNumber' => 'SW100.1', 'size' => 'S', 'color' => 'green', 'material' => 'cotton'],
+            'SW100.2' => ['productNumber' => 'SW100.2', 'size' => 'M', 'color' => 'green', 'material' => 'cotton'],
+            'SW100.3' => ['productNumber' => 'SW100.3', 'size' => 'S', 'color' => 'green', 'material' => 'linen'],
+            'SW100.4' => ['productNumber' => 'SW100.4', 'size' => 'M', 'color' => 'green', 'material' => 'linen'],
+            'SW100.5' => ['productNumber' => 'SW100.5', 'size' => 'S', 'color' => 'red', 'material' => 'cotton'],
+            'SW100.6' => ['productNumber' => 'SW100.6', 'size' => 'M', 'color' => 'red', 'material' => 'cotton'],
+            'SW100.7' => ['productNumber' => 'SW100.7', 'size' => 'S', 'color' => 'red', 'material' => 'linen'],
+            'SW100.8' => ['productNumber' => 'SW100.8', 'size' => 'M', 'color' => 'red', 'material' => 'linen'],
+        ];
+        $variants = array_map(fn (array $variantData) => $this->variantMockFactory->create($productEntity, $variantData), $variantsData);
+        array_map(fn (ProductEntity $variant) => $variant->setCustomFields($customFieldsData[$variant->getProductNumber()]), $variants);
+        $productEntity->setChildren($this->getProductCollection($variants));
+
+        // Expect
+        $this->feedPreprocessorReader->read($productEntity->getProductNumber(), Argument::any())->willReturn(
+            $this->getFeedPreprocessorEntries(
+                $productEntity,
+                array_map(fn(string $productNumber, array $data) => $variantsData[$productNumber] + $feedPreprocessorReaderData[$productNumber], array_keys($feedPreprocessorReaderData), array_values($feedPreprocessorReaderData))
+            )
+        );
+
+        /** @var ExportProductEntity[] $entities */
+        $entities = iterator_to_array($this->createEntities($productEntity)->getWrappedObject());
+
+        foreach ($expectedValues as $key => $expectedValue) {
+            $gluedCustomFields = explode('|', trim($entities[$key]->getCustomFields(), '|'));
+            sort($gluedCustomFields);
+            $gluedCustomFields = sprintf('|%s|', implode('|', $gluedCustomFields));
+            Assert::assertEquals($expectedValue, $gluedCustomFields);
+        }
+    }
+
+    /**
+     * @var ProductEntity[] $expectedVariants
+     * @return FeedPreprocessorEntry[]
+     */
+    private function getFeedPreprocessorEntries(ProductEntity $parent, array $variantsData): array
+    {
+        return array_reduce(
+            $variantsData,
+            fn(array $acc, array $variantData): array => $acc + [
+                $variantData['productNumber'] => $this->feedPreprocessorEntryMockFactory->create(
+                    $this->variantMockFactory->create($parent, $variantData),
+                    [
+                        'filterAttributes' => $variantData['filterAttributes'],
+                        'customFields' => $variantData['customFields'] ?? '',
+                        'additionalCache' => $variantData['additionalCache'] ?? []
+                    ]
+                )
+            ],
+            []
+        );
+    }
+
+    /**
+     * @param ProductEntity[] $variants
+     */
+    private function getProductCollection(array $variants): ProductCollection
+    {
+        return new ProductCollection(
+            array_reduce(
+                $variants,
+                fn(array $carriedVariants, ProductEntity $product): array =>
+                    $carriedVariants + [$product->getId() => $this->salesChannelProductMockFactory->create($product)],
+                []
+            ));
+    }
+}

--- a/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
+++ b/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
@@ -134,6 +134,7 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
             $this->exportProductMockFactory->create($variants['SW100.10'], ['filterAttributes' => $filterAttributes['SW100.10'], 'parent' => $productEntity]),
             $this->exportProductMockFactory->create($variants['SW100.13'], ['filterAttributes' => $filterAttributes['SW100.13'], 'parent' => $productEntity]),
             $this->exportProductMockFactory->create($variants['SW100.16'], ['filterAttributes' => $filterAttributes['SW100.16'], 'parent' => $productEntity]),
+            $this->exportProductMockFactory->create($productEntity),
         ];
         $productEntity->setChildren($this->getProductCollection($variants));
 

--- a/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
+++ b/spec/Export/Data/Factory/PreprocessedProductEntityFactorySpec.php
@@ -128,12 +128,12 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
             'SW100.16' => 'size=S|size=M|size=L|color=green|material=linen',
         ];
         $expectedVariants = [
-            $this->exportProductMockFactory->create($variants['SW100.1'], ['filterAttributes' => $filterAttributes['SW100.1']]),
-            $this->exportProductMockFactory->create($variants['SW100.5'], ['filterAttributes' => $filterAttributes['SW100.5']]),
-            $this->exportProductMockFactory->create($variants['SW100.7'], ['filterAttributes' => $filterAttributes['SW100.7']]),
-            $this->exportProductMockFactory->create($variants['SW100.10'], ['filterAttributes' => $filterAttributes['SW100.10']]),
-            $this->exportProductMockFactory->create($variants['SW100.13'], ['filterAttributes' => $filterAttributes['SW100.13']]),
-            $this->exportProductMockFactory->create($variants['SW100.16'], ['filterAttributes' => $filterAttributes['SW100.16']]),
+            $this->exportProductMockFactory->create($variants['SW100.1'], ['filterAttributes' => $filterAttributes['SW100.1'], 'parent' => $productEntity]),
+            $this->exportProductMockFactory->create($variants['SW100.5'], ['filterAttributes' => $filterAttributes['SW100.5'], 'parent' => $productEntity]),
+            $this->exportProductMockFactory->create($variants['SW100.7'], ['filterAttributes' => $filterAttributes['SW100.7'], 'parent' => $productEntity]),
+            $this->exportProductMockFactory->create($variants['SW100.10'], ['filterAttributes' => $filterAttributes['SW100.10'], 'parent' => $productEntity]),
+            $this->exportProductMockFactory->create($variants['SW100.13'], ['filterAttributes' => $filterAttributes['SW100.13'], 'parent' => $productEntity]),
+            $this->exportProductMockFactory->create($variants['SW100.16'], ['filterAttributes' => $filterAttributes['SW100.16'], 'parent' => $productEntity]),
         ];
         $productEntity->setChildren($this->getProductCollection($variants));
 
@@ -157,12 +157,24 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
         );
     }
 
-    public function it_should_create_entities_with_cached_category_path(CategoryPath $categoryPathField, FieldsProvider $fieldsProvider)
-    {
+    public function it_should_create_entities_with_cached_category_path(
+        CategoryPath $categoryPathField,
+        FieldsProvider $fieldsProvider,
+        FeedPreprocessorEntryPersister $entryPersister
+    ) {
         // Given
         $categoryPathName = 'CategoryPath';
         $categoryPathValue = 'Sports/Books%2C+Clothing+%26+Games/Movies%2C+Electronics+%26+Clothing';
-        $this->beConstructedWith($this->decoratedFactory, $this->salesChannelService, $fieldsProvider, $this->exportSettings, $this->feedPreprocessorReader, $this->cachedFields);
+        $this->beConstructedWith(
+            $this->decoratedFactory,
+            $this->salesChannelService,
+            $fieldsProvider,
+            $this->exportSettings,
+            $this->feedPreprocessorReader,
+            $entryPersister,
+            $this->feedPreprocessor,
+            $this->cachedFields
+        );
 
         $productEntity = $this->productMockFactory->create();
         $variantsData = [
@@ -174,7 +186,7 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
             'SW100.1' => 'size=S|size=M|color=red|material=cotton',
             'SW100.2' => 'size=S|size=M|color=blue|material=cotton',
         ];
-        $expectedVariants = array_map(function(array $expectedVariantData) use ($filterAttributes, $categoryPathField, $variants, $categoryPathName, $categoryPathValue): ExportProductEntity {
+        $expectedVariants = array_map(function(array $expectedVariantData) use ($filterAttributes, $categoryPathField, $variants, $categoryPathName, $categoryPathValue, $productEntity): ExportProductEntity {
             $productNumber = $expectedVariantData['productNumber'];
             $product = $variants[$productNumber];
             $categoryPathField->getName()->willReturn($categoryPathName);
@@ -186,6 +198,7 @@ class PreprocessedProductEntityFactorySpec extends ObjectBehavior
                     'filterAttributes' => $filterAttributes[$productNumber],
                     'additionalCache' => [$categoryPathName => $categoryPathValue],
                     'productFields' => [$categoryPathField->getWrappedObject()],
+                    'parent' => $productEntity
                 ]
             );
         }, $variantsData);

--- a/src/Command/DataExportCommand.php
+++ b/src/Command/DataExportCommand.php
@@ -158,8 +158,8 @@ class DataExportCommand extends Command implements ContainerAwareInterface
         $feedColumns      = $this->getFeedColumns($exportType, $entityClass);
 
         $needFile = $saveFile || $uploadFeed;
-        $output   = $needFile ? new CsvFile($this->createFile($exportType, $context->getSalesChannelId())) : new ConsoleOutput($output);
-        $feedService->generate($output, $feedColumns);
+        $out      = $needFile ? new CsvFile($this->createFile($exportType, $context->getSalesChannelId())) : new ConsoleOutput($output);
+        $feedService->generate($out, $feedColumns);
 
         if ($uploadFeed) {
             $this->uploadService->upload($this->file);

--- a/src/Command/RunPreprocessorCommand.php
+++ b/src/Command/RunPreprocessorCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Command;
+
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessor;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryPersister;
+use Omikron\FactFinder\Shopware6\Export\ExportProducts;
+use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ElseExpression)
+ */
+class RunPreprocessorCommand extends Command
+{
+    public const SALES_CHANNEL_ARGUMENT          = 'sales_channel';
+    public const SALES_CHANNEL_LANGUAGE_ARGUMENT = 'language';
+
+    private FeedPreprocessor $feedPreprocessor;
+    private FeedPreprocessorEntryPersister $entryPersister;
+    private ExportProducts $exportProducts;
+    private SalesChannelService $channelService;
+    private EntityRepositoryInterface $languageRepository;
+    private EntityRepositoryInterface $channelRepository;
+
+    public function __construct(
+        FeedPreprocessor $feedPreprocessor,
+        FeedPreprocessorEntryPersister $entryPersister,
+        SalesChannelService $salesChannelService,
+        ExportProducts $exportProducts,
+        EntityRepositoryInterface $languageRepository,
+        EntityRepositoryInterface $channelRepository
+    ) {
+        parent::__construct();
+        $this->feedPreprocessor   = $feedPreprocessor;
+        $this->entryPersister     = $entryPersister;
+        $this->channelService     = $salesChannelService;
+        $this->exportProducts     = $exportProducts;
+        $this->languageRepository = $languageRepository;
+        $this->channelRepository  = $channelRepository;
+    }
+
+    public function configure(): void
+    {
+        $this->setName('factfinder:data:pre-process');
+        $this->setDescription('Run the Feed preprocessor');
+        $this->addArgument(self::SALES_CHANNEL_LANGUAGE_ARGUMENT, InputArgument::OPTIONAL, 'ID of the sales channel language');
+        $this->addArgument(self::SALES_CHANNEL_ARGUMENT, InputArgument::OPTIONAL, 'ID of the sales channel');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->isInteractive()) {
+            $helper           = $this->getHelper('question');
+            $salesChannel     = $this->getSalesChannel($helper->ask($input, $output, new Question('ID of the sales channel (leave empty if no value): ')));
+            $language         = $this->getLanguage($helper->ask($input, $output, new Question('ID of the sales channel language (leave empty if no value): ')));
+        } else {
+            $salesChannel = $this->getSalesChannel($input->getArgument(self::SALES_CHANNEL_ARGUMENT));
+            $language     = $this->getLanguage($input->getArgument(self::SALES_CHANNEL_LANGUAGE_ARGUMENT));
+        }
+
+        $salesChannelContext = $this->channelService->getSalesChannelContext($salesChannel, $language->getId());
+        $context             = $salesChannelContext->getContext();
+
+        /** @var ProductEntity $product */
+        foreach ($this->exportProducts->getByContext($salesChannelContext) as $product) {
+            $this->entryPersister->deleteAllProductEntries($product->getProductNumber(), $context);
+            $this->entryPersister->insertProductEntries($this->feedPreprocessor->createEntries($product, $context), $context);
+        }
+
+        return 0;
+    }
+
+    private function getLanguage(string $id = null): LanguageEntity
+    {
+        return $this->languageRepository->search(
+            new Criteria([$id ?: Defaults::LANGUAGE_SYSTEM]),
+            new Context(new SystemSource())
+        )->first();
+    }
+
+    private function getSalesChannel(string $id = null): ?SalesChannelEntity
+    {
+        return !is_null($id)
+            ? $this->channelRepository->search(new Criteria([$id]), new Context(new SystemSource()))->first()
+            : null;
+    }
+}

--- a/src/Config/ExportSettings.php
+++ b/src/Config/ExportSettings.php
@@ -21,6 +21,11 @@ class ExportSettings extends BaseConfig
         return (bool) $this->config('currencyPriceExport');
     }
 
+    public function isExportCacheEnable(): bool
+    {
+        return (bool) $this->config('enableExportCache');
+    }
+
     private function toArray(?array $value): array
     {
         return (array) $value;

--- a/src/DataAbstractionLayer/FeedPreprocessor.php
+++ b/src/DataAbstractionLayer/FeedPreprocessor.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
+
+use Omikron\FactFinder\Shopware6\Events\FeedPreprocessorEntryBeforeCreate;
+use Omikron\FactFinder\Shopware6\Export\Field\CustomFields as ExportCustomFields;
+use Omikron\FactFinder\Shopware6\Export\PropertyFormatter;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function Omikron\FactFinder\Shopware6\Internal\Utils\flatMap;
+use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;
+
+class FeedPreprocessor
+{
+    private PropertyFormatter $propertyFormatter;
+    private EventDispatcherInterface $eventDispatcher;
+    private ExportCustomFields $customFields;
+
+    public function __construct(
+        PropertyFormatter $propertyFormatter,
+        EventDispatcherInterface $eventDispatcher,
+        ExportCustomFields $customFields
+    ) {
+        $this->propertyFormatter = $propertyFormatter;
+        $this->eventDispatcher   = $eventDispatcher;
+        $this->customFields      = $customFields;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function createEntries(ProductEntity $product, Context $context): array
+    {
+        $noVisibleVariantsFilters = [];
+        $visibleVariantsFilters   = [];
+        $notVisibleGroups         = [];
+        $entries                  = [];
+        $customFields             = [];
+
+        if ($product->getChildCount() === 0) {
+            $customFields = explode('|', $this->customFields->getValue($product));
+            $entry        = $this->formEntry($product, $context, implode('|', array_unique($customFields)));
+            $event        = new FeedPreprocessorEntryBeforeCreate($entry, $context);
+            $this->eventDispatcher->dispatch($event);
+
+            return [$event->getEntry()];
+        }
+
+        $visibleGroupIds = $this->extractVisibleGroupIds($product);
+
+        /** @var \Shopware\Core\Content\Product\ProductEntity $child */
+        foreach ($product->getChildren() as $child) {
+            //fetch storefront presentation config for each variant
+            $shouldGroupBeVisible = fn (string $groupId): bool => in_array($groupId, $visibleGroupIds);
+            $variationKeyParts    = [];
+
+            //loop over the options to collect those, that should be aggregated in exported products
+            foreach ($child->getOptions() as $option) {
+                $hasMainVariant = (bool) $product->getMainVariantId();
+
+                if (($shouldGroupBeVisible($option->getGroupId()) || $visibleGroupIds === []) && !$hasMainVariant) {
+                    /*
+                     * if a given option should be presented on storefront, we store its id
+                     * This is used later to collect only unique combination of product variants
+                     */
+                    $variationKeyParts[] = $option->getId();
+
+                    continue;
+                }
+
+                //if not then we format the option to a "ready to be exported" expression
+                $notVisibleGroups[$option->getGroupId()][$option->getId()] = call_user_func($this->propertyFormatter, $option);
+            }
+
+            //collect all variants that should be visible used variation key created in a loop before
+            $variationKey = implode('-', $variationKeyParts);
+
+            $childCustomFields = explode('|', $this->customFields->getValue($child));
+
+            foreach ($childCustomFields as $childCustomField) {
+                $customFields[$variationKey][] = $childCustomField;
+            }
+
+            //store variant data to prevent iterating them again later
+            $entries[$variationKey]                  = $this->formEntry($product, $context, $variationKey);
+            $entries[$variationKey]['productNumber'] = $child->getProductNumber();
+
+            $noVisibleVariantsFilters[$variationKey] = implode('|', flatMap(fn (
+                array $groupOptions) => array_values($groupOptions), array_values($notVisibleGroups)));
+
+            $visibleVariantsFilters[$variationKey] = implode('|', array_filter($child->getOptions()->map(fn (
+                PropertyGroupOptionEntity $option): string => in_array($option->getGroupId(), $visibleGroupIds) ? call_user_func($this->propertyFormatter, $option) : '')));
+        }
+
+        return array_map(function (array $entry) use ($visibleVariantsFilters, $noVisibleVariantsFilters, $customFields, $context) {
+            $variationKey = $entry['variationKey'];
+            $filters = implode('|', array_filter([$noVisibleVariantsFilters[$variationKey], $visibleVariantsFilters[$variationKey]]));
+            $entry['filterAttributes'] = $filters ? "|$filters|" : '';
+            $entry['customFields'] = array_filter($customFields[$variationKey]) ? sprintf('|%s|', trim(implode('|', array_unique($customFields[$variationKey])), '|')) : '';
+            $event = new FeedPreprocessorEntryBeforeCreate($entry, $context);
+            $this->eventDispatcher->dispatch($event);
+
+            return $event->getEntry();
+        }, $entries);
+    }
+
+    private function extractVisibleGroupIds(ProductEntity $product): array
+    {
+        $configuratorGroupConfig = $product->getConfiguratorGroupConfig();
+        $hasMainVariant          = (bool) $product->getMainVariantId();
+
+        if (!$configuratorGroupConfig) {
+            return [];
+        }
+        return array_reduce(
+            array_filter($product->getConfiguratorGroupConfig(),
+                fn (
+                    array $groupConfig): bool => !$hasMainVariant && (bool) safeGetByName($groupConfig, 'expressionForListings')),
+            fn (
+                array $result,
+                array $groupConfig): array => array_merge($result, [safeGetByName($groupConfig, 'id')]), []
+        );
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    private function formEntry(
+        ProductEntity $product,
+        Context $context,
+        ?string $variationKey = '',
+        ?array $customFields = null,
+        ?array $filterAttributes = null
+    ): array {
+        return [
+            'id'                  => Uuid::randomHex(),
+            'productNumber'       => $product->getProductNumber(),
+            'variationKey'        => $variationKey,
+            'parentProductNumber' => $product->getProductNumber(),
+            'languageId'          => Uuid::fromHexToBytes($context->getLanguageId()),
+            'filterAttributes'    => $filterAttributes ? "|$filterAttributes|" : '',
+            'customFields'        => $customFields ? "|$customFields|" : '',
+        ];
+    }
+}

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryPersister.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+
+class FeedPreprocessorEntryPersister
+{
+    private EntityRepository $entryRepository;
+
+    public function __construct(EntityRepository $entryRepository)
+    {
+        $this->entryRepository = $entryRepository;
+    }
+
+    public function deleteAllProductEntries(string $productNumber, Context $context): void
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
+        $ids = array_map(fn (
+            string $id): array => ['id' => $id], $this->entryRepository->searchIds($criteria, $context)->getIds());
+
+        $this->entryRepository->delete($ids, $context);
+    }
+
+    /**
+     * @param array[FeedPreprocessorEntry] $entries
+     * @param Context $context
+     */
+    public function insertProductEntries(array $entries, Context $context): void
+    {
+        $this->entryRepository->create(array_values($entries), $context);
+    }
+}

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
+
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class FeedPreprocessorEntryReader
+{
+    private SalesChannelService $channelService;
+    private EntityRepositoryInterface $entryRepository;
+
+    public function __construct(
+        SalesChannelService $channelService,
+        EntityRepositoryInterface $entryRepository
+    ) {
+        $this->channelService  = $channelService;
+        $this->entryRepository = $entryRepository;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     *
+     * @return FeedPreprocessorEntry[]
+     */
+    public function read(string $productNumber, ?string $languageId): array
+    {
+        $context  = $this->channelService->getSalesChannelContext()->getContext();
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('parentProductNumber', $productNumber));
+
+        if ($languageId) {
+            $criteria->addFilter(new EqualsFilter('languageId', Uuid::fromHexToBytes($context->getLanguageId())));
+        }
+
+        $preprocessedFeeds = $this->entryRepository->search($criteria, $context)->getElements();
+
+        return array_reduce($preprocessedFeeds, function (array $acc, FeedPreprocessorEntry $preprocessedFeed) {
+            $number = $preprocessedFeed->getProductNumber();
+
+            if ($number !== null) {
+                $acc[$number] = $preprocessedFeed;
+            }
+
+            return $acc;
+        }, []);
+    }
+}

--- a/src/Events/FeedPreprocessorEntryBeforeCreate.php
+++ b/src/Events/FeedPreprocessorEntryBeforeCreate.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Events;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareEvent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class FeedPreprocessorEntryBeforeCreate extends Event implements ShopwareEvent
+{
+    private array $entry;
+    private Context $context;
+
+    public function __construct(array $entry, Context $context)
+    {
+        $this->entry   = $entry;
+        $this->context = $context;
+    }
+
+    public function getEntry(): array
+    {
+        return $this->entry;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    public function setEntry(array $entry): void
+    {
+        $this->entry = $entry;
+    }
+}

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -8,7 +8,7 @@ use ArrayIterator;
 use Omikron\FactFinder\Shopware6\Export\Data\ExportEntityInterface;
 use Omikron\FactFinder\Shopware6\Export\Field\FieldInterface;
 use Shopware\Core\Content\Product\ProductCollection;
-use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
+use Shopware\Core\Content\Product\ProductEntity as Product;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
 use Traversable;
 use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -4,23 +4,38 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Export\Data\Entity;
 
+use ArrayIterator;
 use Omikron\FactFinder\Shopware6\Export\Data\ExportEntityInterface;
 use Omikron\FactFinder\Shopware6\Export\Field\FieldInterface;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
+use Traversable;
+use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
 
-class ProductEntity implements ExportEntityInterface
+class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 {
     private Product $product;
+    private ?Product $parent         = null;
+    private string $filterAttributes = '';
+    private string $customFields     = '';
+    private Traversable $additionalCache;
 
     /** @var FieldInterface[] */
     private iterable $productFields;
 
-    public function __construct(Product $product, iterable $productFields)
-    {
-        $this->product       = $product;
-        $this->productFields = $productFields;
+    /** @var FieldInterface[] */
+    private iterable $cachedProductFields;
+
+    public function __construct(
+        Product $product,
+        Traversable $productFields,
+        Traversable $cachedProductFields
+    ) {
+        $this->product             = $product;
+        $this->productFields       = iterator_to_array($productFields);
+        $this->cachedProductFields = $cachedProductFields;
+        $this->additionalCache     = new ArrayIterator();
     }
 
     public function getId(): string
@@ -38,12 +53,63 @@ class ProductEntity implements ExportEntityInterface
         return $this->product->getProperties();
     }
 
+    public function getProductNumber(): string
+    {
+        return $this->product->getProductNumber();
+    }
+
+    public function getFilterAttributes(): string
+    {
+        return $this->filterAttributes;
+    }
+
+    public function getAdditionalCache(string $key): ?string
+    {
+        return safeGetByName(iterator_to_array($this->additionalCache), $key);
+    }
+
+    public function setFilterAttributes(string $filterAttributes): void
+    {
+        $this->filterAttributes = $filterAttributes;
+    }
+
+    public function setAdditionalCache(Traversable $additionalCache): void
+    {
+        $this->additionalCache = $additionalCache;
+    }
+
+    public function getCustomFields(): string
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(string $customFields): void
+    {
+        $this->customFields = $customFields;
+    }
+
+    public function setParent(?Product $parent): void
+    {
+        $this->parent = $parent;
+    }
+
     public function toArray(): array
     {
-        return array_reduce($this->productFields, fn (array $fields, FieldInterface $field): array => $fields + [$field->getName() => $field->getValue($this->product)], [
-            'ProductNumber' => $this->product->getProductNumber(),
-            'Master'        => $this->product->getProductNumber(),
-            'Name'          => (string) $this->product->getTranslation('name'),
-        ]);
+        $cachedProductFieldNames = array_map(fn (FieldInterface $field) => $field->getName(), iterator_to_array($this->cachedProductFields));
+        $fields                  = array_filter($this->productFields, fn (FieldInterface $productField) => !in_array($productField->getName(), $cachedProductFieldNames));
+        $isVariant               = $this->product->getId() !== $this->product->getParentId() && isset($this->parent);
+        $defaultFields           = [
+            'ProductNumber'    => $this->product->getProductNumber(),
+            'Master'           => $isVariant ? $this->parent->getProductNumber() : $this->product->getProductNumber(),
+            'Name'             => (string) $this->product->getTranslation('name'),
+            'FilterAttributes' => $this->getFilterAttributes(),
+            'CustomFields'     => $this->getCustomFields(),
+        ];
+
+        return array_reduce(
+            $fields,
+            fn (array $fields, FieldInterface $field): array => $fields + [$field->getName() => ($this->getAdditionalCache($field->getName()) ?? $field->getValue($isVariant ? $this->parent : $this->product))],
+            $defaultFields
+        );
     }
 }

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -9,9 +9,9 @@ use Omikron\FactFinder\Shopware6\Export\Data\ExportEntityInterface;
 use Omikron\FactFinder\Shopware6\Export\Field\FieldInterface;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
 use Traversable;
 use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;
-use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
 
 class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 {

--- a/src/Export/Data/Entity/ProductEntityInterface.php
+++ b/src/Export/Data/Entity/ProductEntityInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export\Data\Entity;
+
+interface ProductEntityInterface
+{
+    public function getProductNumber(): string;
+}

--- a/src/Export/Data/Entity/VariantEntity.php
+++ b/src/Export/Data/Entity/VariantEntity.php
@@ -10,7 +10,7 @@ use Omikron\FactFinder\Shopware6\Export\PropertyFormatter;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity as Product;
 use function array_map as map;
 
-class VariantEntity implements ExportEntityInterface
+class VariantEntity implements ExportEntityInterface, ProductEntityInterface
 {
     private Product $product;
     private array $parentData;
@@ -34,6 +34,11 @@ class VariantEntity implements ExportEntityInterface
     public function getId(): string
     {
         return $this->product->getId();
+    }
+
+    public function getProductNumber(): string
+    {
+        return $this->product->getProductNumber();
     }
 
     public function toArray(): array

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -98,6 +98,10 @@ class PreprocessedProductEntityFactory implements FactoryInterface
             }
         }
 
+        if ($entity->getConfiguratorGroupConfig()) {
+            return;
+        }
+
         $exportProduct = $this->getExportProduct($entity, $entity, []);
 
         if (isset($exportProduct)) {

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -81,22 +81,34 @@ class PreprocessedProductEntityFactory implements FactoryInterface
         }
 
         if ($entity->getChildCount() === 0) {
-            yield $this->getExportProduct($entity, $entity, $preprocessedEntries);
+            $exportProduct = $this->getExportProduct($entity, $entity, $preprocessedEntries);
+
+            if (isset($exportProduct)) {
+                yield $exportProduct;
+            }
 
             return;
         }
 
         foreach ($entity->getChildren() as $child) {
-            yield $this->getExportProduct($child, $entity, $preprocessedEntries);
+            $exportProduct = $this->getExportProduct($child, $entity, $preprocessedEntries);
+
+            if (isset($exportProduct)) {
+                yield $exportProduct;
+            }
         }
 
-        yield $this->getExportProduct($entity, $entity, []);
+        $exportProduct = $this->getExportProduct($entity, $entity, []);
+
+        if (isset($exportProduct)) {
+            yield $exportProduct;
+        }
     }
 
     /**
      * @param FeedPreprocessorEntry[] $preprocessedEntries
      */
-    private function getExportProduct(SalesChannelProductEntity $entity, ProductEntity $parent, array $preprocessedEntries): ?ExportProductEntity
+    private function getExportProduct(ProductEntity $entity, ProductEntity $parent, array $preprocessedEntries): ?ExportProductEntity
     {
         $fields = $this->fieldsProviders->getFields(ExportProductEntity::class);
         $cache  = $preprocessedEntries[$entity->getProductNumber()] ?? null;
@@ -111,6 +123,10 @@ class PreprocessedProductEntityFactory implements FactoryInterface
             return $exportProduct;
         }
 
-        return new ExportProductEntity($entity, new ArrayIterator($fields), new ArrayIterator());
+        if ($entity === $parent) {
+            return new ExportProductEntity($entity, new ArrayIterator($fields), new ArrayIterator());
+        }
+
+        return null;
     }
 }

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export\Data\Factory;
+
+use ArrayIterator;
+use Omikron\FactFinder\Shopware6\Config\ExportSettings;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessor;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryPersister;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryReader;
+use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Omikron\FactFinder\Shopware6\Export\FieldsProvider;
+use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Traversable;
+
+class PreprocessedProductEntityFactory implements FactoryInterface
+{
+    private SalesChannelService $channelService;
+    private FactoryInterface $decoratedFactory;
+    private FieldsProvider $fieldsProviders;
+    private ExportSettings $exportSettings;
+    private FeedPreprocessorEntryReader $feedPreprocessorReader;
+    private FeedPreprocessorEntryPersister $entryPersister;
+    private FeedPreprocessor $feedPreprocessor;
+    private iterable $cachedFields;
+
+    public function __construct(
+        FactoryInterface $decoratedFactory,
+        SalesChannelService $channelService,
+        FieldsProvider $fieldsProviders,
+        ExportSettings $exportSettings,
+        FeedPreprocessorEntryReader $feedPreprocessorReader,
+        FeedPreprocessorEntryPersister $entryPersister,
+        FeedPreprocessor $feedPreprocessor,
+        Traversable $cachedFields
+    ) {
+        $this->channelService         = $channelService;
+        $this->decoratedFactory       = $decoratedFactory;
+        $this->fieldsProviders        = $fieldsProviders;
+        $this->exportSettings         = $exportSettings;
+        $this->feedPreprocessorReader = $feedPreprocessorReader;
+        $this->entryPersister         = $entryPersister;
+        $this->feedPreprocessor       = $feedPreprocessor;
+        $this->cachedFields           = $cachedFields;
+    }
+
+    public function handle(Entity $entity): bool
+    {
+        return in_array(get_class($entity), [SalesChannelProductEntity::class]);
+    }
+
+    /**
+     * @return ExportProductEntity[]|iterable
+     */
+    public function createEntities(Entity $entity, string $producedType = ExportProductEntity::class): iterable
+    {
+        if ($this->exportSettings->isExportCacheEnable() === false) {
+            yield from $this->decoratedFactory->createEntities($entity, $producedType);
+
+            return;
+        }
+
+        $salesChannelcontext = $this->channelService->getSalesChannelContext();
+        $context             = $salesChannelcontext->getContext();
+        $preprocessedEntries = $this->feedPreprocessorReader->read(
+            $entity->getProductNumber(),
+            $salesChannelcontext->getLanguageId()
+        );
+
+        if ($preprocessedEntries === []) {
+            $this->entryPersister->insertProductEntries($this->feedPreprocessor->createEntries($entity, $context), $context);
+
+            yield from $this->decoratedFactory->createEntities($entity, $producedType);
+
+            return;
+        }
+
+        if ($entity->getChildCount() === 0) {
+            $exportProduct = $this->getExportProduct($entity, $entity, $preprocessedEntries);
+
+            if (isset($exportProduct)) {
+                yield $exportProduct;
+            }
+
+            return;
+        }
+
+        foreach ($entity->getChildren() as $child) {
+            $exportProduct = $this->getExportProduct($child, $entity, $preprocessedEntries);
+
+            if (isset($exportProduct)) {
+                yield $exportProduct;
+            }
+        }
+    }
+
+    /**
+     * @param FeedPreprocessorEntry[] $preprocessedEntries
+     */
+    private function getExportProduct(SalesChannelProductEntity $entity, SalesChannelProductEntity $parent, array $preprocessedEntries): ?ExportProductEntity
+    {
+        $fields = $this->fieldsProviders->getFields(SalesChannelProductEntity::class);
+        $cache  = $preprocessedEntries[$entity->getProductNumber()] ?? null;
+
+        if (isset($cache)) {
+            $exportProduct = new ExportProductEntity($entity, new ArrayIterator($fields), $this->cachedFields);
+            $exportProduct->setFilterAttributes($cache->getFilterAttributes());
+            $exportProduct->setCustomFields($cache->getCustomFields());
+            $exportProduct->setAdditionalCache(new ArrayIterator($cache->getAdditionalCache()));
+            $exportProduct->setParent($parent);
+
+            return $exportProduct;
+        }
+
+        return null;
+    }
+}

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -81,22 +81,16 @@ class PreprocessedProductEntityFactory implements FactoryInterface
         }
 
         if ($entity->getChildCount() === 0) {
-            $exportProduct = $this->getExportProduct($entity, $entity, $preprocessedEntries);
-
-            if (isset($exportProduct)) {
-                yield $exportProduct;
-            }
+            yield $this->getExportProduct($entity, $entity, $preprocessedEntries);
 
             return;
         }
 
         foreach ($entity->getChildren() as $child) {
-            $exportProduct = $this->getExportProduct($child, $entity, $preprocessedEntries);
-
-            if (isset($exportProduct)) {
-                yield $exportProduct;
-            }
+            yield $this->getExportProduct($child, $entity, $preprocessedEntries);
         }
+
+        yield $this->getExportProduct($entity, $entity, []);
     }
 
     /**
@@ -104,7 +98,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
      */
     private function getExportProduct(SalesChannelProductEntity $entity, ProductEntity $parent, array $preprocessedEntries): ?ExportProductEntity
     {
-        $fields = $this->fieldsProviders->getFields(SalesChannelProductEntity::class);
+        $fields = $this->fieldsProviders->getFields(ExportProductEntity::class);
         $cache  = $preprocessedEntries[$entity->getProductNumber()] ?? null;
 
         if (isset($cache)) {
@@ -117,6 +111,6 @@ class PreprocessedProductEntityFactory implements FactoryInterface
             return $exportProduct;
         }
 
-        return null;
+        return new ExportProductEntity($entity, new ArrayIterator($fields), new ArrayIterator());
     }
 }

--- a/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
+++ b/src/Export/Data/Factory/PreprocessedProductEntityFactory.php
@@ -13,6 +13,7 @@ use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProdu
 use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
 use Omikron\FactFinder\Shopware6\Export\FieldsProvider;
 use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
+use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Traversable;
@@ -101,7 +102,7 @@ class PreprocessedProductEntityFactory implements FactoryInterface
     /**
      * @param FeedPreprocessorEntry[] $preprocessedEntries
      */
-    private function getExportProduct(SalesChannelProductEntity $entity, SalesChannelProductEntity $parent, array $preprocessedEntries): ?ExportProductEntity
+    private function getExportProduct(SalesChannelProductEntity $entity, ProductEntity $parent, array $preprocessedEntries): ?ExportProductEntity
     {
         $fields = $this->fieldsProviders->getFields(SalesChannelProductEntity::class);
         $cache  = $preprocessedEntries[$entity->getProductNumber()] ?? null;

--- a/src/Export/Data/Factory/ProductEntityFactory.php
+++ b/src/Export/Data/Factory/ProductEntityFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Export\Data\Factory;
 
+use ArrayIterator;
 use Omikron\FactFinder\Shopware6\Export\CurrencyFieldsProvider;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\VariantEntity;
@@ -41,14 +42,14 @@ class ProductEntityFactory implements FactoryInterface
      * @param Entity $entity
      * @param string $producedType
      *
-     * @return iterable
+     * @return ProductEntity[]|iterable
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function createEntities(Entity $entity, string $producedType = ProductEntity::class): iterable
     {
         //@todo use spread operator?
         $fields = array_merge($this->fieldsProvider->getFields($producedType), $this->currencyFieldsProvider->getCurrencyFields());
-        $parent = new $producedType($entity, $fields);
+        $parent = new $producedType($entity, new ArrayIterator($fields), new ArrayIterator());
         if ($entity->getChildCount()) {
             yield from $entity->getChildren()->map(fn (
                 SalesChannelProductEntity $child) => new VariantEntity($child, $parent->toArray(), $this->propertyFormatter, iterator_to_array($this->variantFields)));

--- a/src/Export/FeedPreprocessorEntry.php
+++ b/src/Export/FeedPreprocessorEntry.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+
+class FeedPreprocessorEntry extends Entity
+{
+    protected ?string $id;
+    protected ?string $productNumber;
+    protected ?string $parentProductNumber;
+    protected ?string $variationKey;
+    protected ?string $filterAttributes;
+    protected ?string $customFields;
+    protected ?string $languageId;
+    protected array $additionalCache = [];
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setId(?string $id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getLanguageId(): ?string
+    {
+        return $this->languageId;
+    }
+
+    public function setLanguageId(?string $languageId): self
+    {
+        $this->languageId = $languageId;
+        return $this;
+    }
+
+    public function getProductNumber(): ?string
+    {
+        return $this->productNumber;
+    }
+
+    public function setProductNumber(?string $productNumber): self
+    {
+        $this->productNumber = $productNumber;
+        return $this;
+    }
+
+    public function getParentProductNumber(): ?string
+    {
+        return $this->parentProductNumber;
+    }
+
+    public function setParentProductNumber(?string $parentProductNumber): self
+    {
+        $this->parentProductNumber = $parentProductNumber;
+        return $this;
+    }
+
+    public function getVariationKey(): ?string
+    {
+        return $this->variationKey;
+    }
+
+    public function setVariationKey(?string $variationKey): self
+    {
+        $this->variationKey = $variationKey;
+        return $this;
+    }
+
+    public function getFilterAttributes(): ?string
+    {
+        return $this->filterAttributes;
+    }
+
+    public function setFilterAttributes(?string $filterAttributes): self
+    {
+        $this->filterAttributes = $filterAttributes;
+        return $this;
+    }
+
+    public function getCustomFields(): ?string
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(?string $customFields): self
+    {
+        $this->customFields = $customFields;
+        return $this;
+    }
+
+    public function getAdditionalCache(): ?array
+    {
+        return $this->additionalCache;
+    }
+
+    public function setAdditionalCache(?array $additionalCache): self
+    {
+        $this->additionalCache = $additionalCache;
+        return $this;
+    }
+}

--- a/src/Export/FeedPreprocessorEntryCollection.php
+++ b/src/Export/FeedPreprocessorEntryCollection.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void                       add(ExampleEntity $entity)
+ * @method void                       set(string $key, ExampleEntity $entity)
+ * @method FeedPreprocessorEntry[]    getIterator()
+ * @method FeedPreprocessorEntry[]    getElements()
+ * @method FeedPreprocessorEntry|null get(string $key)
+ * @method FeedPreprocessorEntry|null first()
+ * @method FeedPreprocessorEntry|null last()
+ */
+class FeedPreprocessorEntryCollection extends EntityCollection
+{
+    public function getExpectedClass(): string
+    {
+        return FeedPreprocessorEntry::class;
+    }
+}

--- a/src/Export/FeedPreprocessorEntryDefinition.php
+++ b/src/Export/FeedPreprocessorEntryDefinition.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Export;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowEmptyString;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class FeedPreprocessorEntryDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'factfinder_feed_preprocessor';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getEntityClass(): string
+    {
+        return FeedPreprocessorEntry::class;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return FeedPreprocessorEntryCollection::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection(
+            [
+                (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+                (new StringField('language_id', 'languageId'))->addFlags(new Required()),
+                (new StringField('product_number', 'productNumber'))->addFlags(new Required()),
+                (new StringField('parent_product_number', 'parentProductNumber')),
+                (new StringField('variation_key', 'variationKey')),
+                (new StringField('filter_attributes', 'filterAttributes'))->addFlags(new Required(), new AllowEmptyString()),
+                (new StringField('custom_fields', 'customFields'))->addFlags(new AllowEmptyString()),
+                (new JsonField('additional_cache', 'additionalCache')),
+            ]
+        );
+    }
+}

--- a/src/Export/Field/CategoryPath.php
+++ b/src/Export/Field/CategoryPath.php
@@ -37,6 +37,10 @@ class CategoryPath implements FieldInterface
 
     public function getValue(Entity $entity): string
     {
+        if ($entity->getCategories($entity) === null) {
+            return '';
+        }
+
         return implode('|', $this->getCategories($entity)->fmap($this->createPath($this->channelService->getSalesChannelContext()->getSalesChannel())));
     }
 

--- a/src/Export/Field/CategoryPath.php
+++ b/src/Export/Field/CategoryPath.php
@@ -37,10 +37,6 @@ class CategoryPath implements FieldInterface
 
     public function getValue(Entity $entity): string
     {
-        if ($entity->getCategories($entity) === null) {
-            return '';
-        }
-
         return implode('|', $this->getCategories($entity)->fmap($this->createPath($this->channelService->getSalesChannelContext()->getSalesChannel())));
     }
 

--- a/src/Export/Field/Deeplink.php
+++ b/src/Export/Field/Deeplink.php
@@ -39,6 +39,10 @@ class Deeplink implements FieldInterface, EventSubscriberInterface
 
     public function getValue(Entity $entity): string
     {
+        if ($entity->getSeoUrls() === null) {
+            return '';
+        }
+
         $url                = $entity->getSeoUrls()->first();
         $getSeoUrlRouteName = fn (Entity $entity) => $entity instanceof ProductEntity ? ProductRoute::ROUTE_NAME : CategoryRoute::ROUTE_NAME;
         $formUrl            = fn (string $url): string => $url ? '/' . ltrim($url, '/') : '';

--- a/src/Migration/Migration1657582730Preprocessor.php
+++ b/src/Migration/Migration1657582730Preprocessor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1657582730Preprocessor extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1657582730;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $query = <<<SQL
+CREATE TABLE IF NOT EXISTS `factfinder_feed_preprocessor` (
+    `id`                           BINARY(16)               NOT NULL,
+    `language_id`                  BINARY(16)               NOT NULL,
+    `product_number`               VARCHAR(255)             NOT NULL,
+    `parent_product_number`        VARCHAR(255),
+    `variation_key`                VARCHAR(255),
+    `filter_attributes`            LONGTEXT                 NOT NULL,
+    `custom_fields`                LONGTEXT                 NOT NULL,
+    `additional_cache`             JSON,
+    `created_at` DATETIME(3) NOT NULL,
+    `updated_at` DATETIME(3),
+    PRIMARY KEY (id)
+)
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_unicode_ci;
+SQL;
+
+        $connection->executeStatement($query);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        $query = <<<SQL
+DROP TABLE IF EXISTS `factfinder_feed_preprocessor`
+SQL;
+        $connection->executeStatement($query);
+    }
+}

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -81,6 +81,11 @@
             <name>currencyPriceExport</name>
             <label>Export Prices for all Currencies</label>
         </input-field>
+
+        <input-field type="checkbox">
+            <name>enableExportCache</name>
+            <label>Enable export cache (decrease export time)</label>
+        </input-field>
     </card>
 
     <card>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -66,11 +66,13 @@
             <bind key="$customFieldRepository" type="service" id="custom_field.repository" />
             <bind key="$languageRepository" type="service" id="language.repository"/>
             <bind key="$variantFields" type="tagged_iterator" tag="factfinder.export.variant_field" />
+            <bind key="$cachedFields" type="tagged_iterator" tag="factfinder.export.cached_product_entity" />
             <bind key="$categoryPathFieldName">%factfinder.navigation.category_path_field_name%</bind>
             <bind key="$customAssociations">%factfinder.export.associations%</bind>
             <bind key="$categoryPageAddParams">%factfinder.category_page.add_params%</bind>
             <bind key="$configurationAddParams">%factfinder.configuration.add_params%</bind>
             <bind key="$communicationParameters">%factfinder.communication.parameters.base%</bind>
+            <bind key="$entryRepository" type="service" id="factfinder_feed_preprocessor.repository" />
         </defaults>
 
         <service id="Omikron\FactFinder\Shopware6\Communication\AdapterFactory" />
@@ -95,7 +97,7 @@
         </instanceof>
 
         <prototype namespace="Omikron\FactFinder\Shopware6\"
-                   resource="../../{Command,Communication,Config,Data,Export,Resources,Storefront,Subscriber,Upload,Service}"
+                   resource="../../{Command,Communication,Config,Data,Export,Resources,Storefront,Subscriber,Upload,Service,DataAbstractionLayer}"
                    exclude="../../Export/Field/{PriceCurrency}.php"
         />
 
@@ -116,9 +118,13 @@
 
         <service id="Omikron\FactFinder\Shopware6\Export\Field\CustomFields">
             <tag name="factfinder.export.variant_field"/>
+            <tag name="factfinder.export.cached_product_entity"/>
         </service>
         <service id="Omikron\FactFinder\Shopware6\Export\Field\ImageUrl">
             <tag name="factfinder.export.variant_field"/>
+        </service>
+        <service id="Omikron\FactFinder\Shopware6\Export\Field\FilterAttributes">
+            <tag name="factfinder.export.cached_product_entity"/>
         </service>
         <service id="Omikron\FactFinder\Shopware6\Api\UiFeedExportController" />
         <service id="Omikron\FactFinder\Shopware6\Api\UpdateFieldRolesController" />
@@ -139,5 +145,24 @@
         </service>
         <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\PriceFormatter" />
         <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter" />
+
+        <service id="Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntryDefinition">
+            <tag name="shopware.entity.definition" entity="factfinder_feed_preprocessor" /></service>
+
+        <service id="Omikron\FactFinder\Shopware6\Subscriber\ProductIndexerSubscriber">
+            <argument type="service" id="product.repository"/>
+            <argument type="service" id="language.repository"/>
+            <argument type="service" id="Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessor"/>
+            <argument type="service" id="Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryPersister"/>
+        </service>
+
+        <service id="Omikron\FactFinder\Shopware6\Export\Data\Factory\PreprocessedProductEntityFactory"
+                 decorates="Omikron\FactFinder\Shopware6\Export\Data\Factory\ProductEntityFactory">
+            <argument type="service" id="Omikron\FactFinder\Shopware6\Export\Data\Factory\PreprocessedProductEntityFactory.inner"/>
+        </service>
+
+        <service id="Omikron\FactFinder\Shopware6\Subscriber\FeedPreprocessorEntrySubscriber">
+            <argument type="service" id="product.repository"/>
+        </service>
     </services>
 </container>

--- a/src/Subscriber/FeedPreprocessorEntrySubscriber.php
+++ b/src/Subscriber/FeedPreprocessorEntrySubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Subscriber;
+
+use Omikron\FactFinder\Shopware6\Events\FeedPreprocessorEntryBeforeCreate;
+use Omikron\FactFinder\Shopware6\Export\Field\CategoryPath;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class FeedPreprocessorEntrySubscriber implements EventSubscriberInterface
+{
+    private CategoryPath $categoryFieldGenerator;
+    private EntityRepositoryInterface $productRepository;
+
+    public function __construct(
+        EntityRepositoryInterface $productRepository,
+        CategoryPath $categoryPath
+    ) {
+        $this->productRepository      = $productRepository;
+        $this->categoryFieldGenerator = $categoryPath;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [FeedPreprocessorEntryBeforeCreate::class => 'onCreateEntry'];
+    }
+
+    public function onCreateEntry(FeedPreprocessorEntryBeforeCreate $event): void
+    {
+        $entry    = $event->getEntry();
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('productNumber', $entry['productNumber']));
+        $criteria->addAssociation('categories');
+        $criteria->addAssociation('categoriesRo');
+        $product                  = $this->productRepository->search($criteria, $event->getContext())->first();
+        $categoryPath             = $this->categoryFieldGenerator->getValue($product);
+        $entry['additionalCache'] = ['CategoryPath' => $categoryPath];
+        $event->setEntry($entry);
+    }
+}

--- a/src/Subscriber/ProductIndexerSubscriber.php
+++ b/src/Subscriber/ProductIndexerSubscriber.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Subscriber;
+
+use Omikron\FactFinder\Shopware6\Config\ExportSettings;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessor;
+use Omikron\FactFinder\Shopware6\DataAbstractionLayer\FeedPreprocessorEntryPersister;
+use Shopware\Core\Content\Product\Events\ProductIndexerEvent;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NandFilter;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ProductIndexerSubscriber implements EventSubscriberInterface
+{
+    private EntityRepositoryInterface $productRepository;
+    private EntityRepositoryInterface $languageRepository;
+    private FeedPreprocessor $feedPreprocessor;
+    private FeedPreprocessorEntryPersister  $entryPersister;
+    private ExportSettings $exportSettings;
+
+    public function __construct(
+        EntityRepositoryInterface $productRepository,
+        EntityRepositoryInterface $languageRepository,
+        FeedPreprocessor $feedPreprocessor,
+        FeedPreprocessorEntryPersister $entryPersister,
+        ExportSettings $exportSettings
+    ) {
+        $this->productRepository  = $productRepository;
+        $this->languageRepository = $languageRepository;
+        $this->feedPreprocessor   = $feedPreprocessor;
+        $this->entryPersister     = $entryPersister;
+        $this->exportSettings     = $exportSettings;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [ProductIndexerEvent::class => 'processVariantsToExport'];
+    }
+
+    public function processVariantsToExport(ProductIndexerEvent $event): void
+    {
+        if ($this->exportSettings->isExportCacheEnable() === false) {
+            return;
+        }
+
+        $languages = $this->fetchLanguages();
+        foreach ($languages as $language) {
+            $context  = $this->createLanguageContext($event, $language);
+            $iterator = $this->getProductsIterator($event->getIds(), $context);
+
+            while ($products = $iterator->fetch()) {
+                foreach ($products as $product) {
+                    $this->entryPersister->deleteAllProductEntries($product->getProductNumber(), $context);
+                    $entries = $this->feedPreprocessor->createEntries($product, $context);
+                    $this->entryPersister->insertProductEntries($entries, $context);
+                }
+            }
+        }
+    }
+
+    private function createLanguageContext(ProductIndexerEvent $event, LanguageEntity $language): Context
+    {
+        return new Context(
+            new SystemSource(),
+            [],
+            Defaults::CURRENCY,
+            array_filter([$language->getId(), $language->getParentId(), Defaults::LANGUAGE_SYSTEM]),
+            $event->getContext()->getVersionId()
+        );
+    }
+
+    private function getProductsIterator(array $productIds, Context $context): RepositoryIterator
+    {
+        $context->setConsiderInheritance(true);
+        $criteria = new Criteria($productIds);
+        $criteria->addAssociation('configuratorGroupConfig');
+        $criteria->addAssociation('children.options.group');
+        return new RepositoryIterator($this->productRepository, $context, $criteria);
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    private function fetchLanguages(): array
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new NandFilter([new EqualsFilter('salesChannelDomains.id', null)]));
+        /** @var LanguageCollection $languages */
+        $languages = $this->languageRepository->search($criteria, Context::createDefaultContext())->getEntities();
+
+        return $languages->getElements();
+    }
+}

--- a/src/TestUtil/ExportProductMockFactory.php
+++ b/src/TestUtil/ExportProductMockFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use ArrayIterator;
+use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
+use Shopware\Core\Content\Product\ProductEntity;
+
+class ExportProductMockFactory
+{
+    private SalesChannelProductMockFactory $productMockFactory;
+
+    public function __construct()
+    {
+        $this->productMockFactory = new SalesChannelProductMockFactory();
+    }
+
+    public function create(ProductEntity $product, $data = []): ExportProductEntity
+    {
+        $productFields       = isset($data['productFields']) ? new ArrayIterator($data['productFields']) : new ArrayIterator();
+        $cachedProductFields = isset($data['cachedProductFields']) ? new ArrayIterator($data['cachedProductFields']) : new ArrayIterator();
+        $entity              = new ExportProductEntity($this->productMockFactory->create($product), $productFields, $cachedProductFields);
+        $entity->setFilterAttributes($data['filterAttributes'] ?? '');
+        $entity->setAdditionalCache(isset($data['additionalCache']) ? new ArrayIterator($data['additionalCache']) : new ArrayIterator());
+
+        return $entity;
+    }
+}

--- a/src/TestUtil/ExportProductMockFactory.php
+++ b/src/TestUtil/ExportProductMockFactory.php
@@ -24,6 +24,7 @@ class ExportProductMockFactory
         $entity              = new ExportProductEntity($this->productMockFactory->create($product), $productFields, $cachedProductFields);
         $entity->setFilterAttributes($data['filterAttributes'] ?? '');
         $entity->setAdditionalCache(isset($data['additionalCache']) ? new ArrayIterator($data['additionalCache']) : new ArrayIterator());
+        $entity->setParent(isset($data['parent']) ? $data['parent'] : null);
 
         return $entity;
     }

--- a/src/TestUtil/FeedPreprocessorEntryMockFactory.php
+++ b/src/TestUtil/FeedPreprocessorEntryMockFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+
+class FeedPreprocessorEntryMockFactory
+{
+    public function create(ProductEntity $product, array $data = []): FeedPreprocessorEntry
+    {
+        $feedPreprocessorEntry = new FeedPreprocessorEntry();
+        $feedPreprocessorEntry->setId($product->getId());
+        $feedPreprocessorEntry->setProductNumber($product->getProductNumber());
+        $feedPreprocessorEntry->setParentProductNumber($product->getParent()->getProductNumber());
+        $feedPreprocessorEntry->setVariationKey($data['variationKey'] ?? '');
+        $feedPreprocessorEntry->setFilterAttributes($data['filterAttributes'] ?? '');
+        $feedPreprocessorEntry->setCustomFields($data['customFields'] ?? '');
+        $feedPreprocessorEntry->setLanguageId($data['languageId'] ?? (new Context(new SystemSource()))->getLanguageId());
+        $feedPreprocessorEntry->setAdditionalCache($data['additionalCache'] ?? []);
+
+        return $feedPreprocessorEntry;
+    }
+}

--- a/src/TestUtil/ProductMockFactory.php
+++ b/src/TestUtil/ProductMockFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+class ProductMockFactory
+{
+    public function create(array $data = []): ProductEntity
+    {
+        $productEntity = new ProductEntity();
+        $productEntity->setId($data['id'] ?? Uuid::randomHex());
+        $productEntity->setProductNumber($data['productNumber'] ?? 'SW100');
+        $productEntity->setConfiguratorGroupConfig($data['configuratorGroupConfig'] ?? self::getGroupConfigurationConfig(
+            [
+                [md5('size'), 'false'],
+                [md5('color'), 'true'],
+                [md5('material'), 'true'],
+            ]
+        ));
+
+        return $productEntity;
+    }
+
+    /**
+     * $groupConfig in format
+     *  [[groupId, true|false]].
+     *
+     * @param array $groupsConfig
+     *
+     * @return array
+     */
+    public static function getGroupConfigurationConfig(array $groupsConfig): array
+    {
+        $row        = '{"id": "%s", "representation": "box", "expressionForListings": %s}';
+        $jsonConfig = array_map(fn (array $groupConfig): array => json_decode(sprintf($row, ...$groupConfig), true), $groupsConfig);
+
+        return $jsonConfig;
+    }
+}

--- a/src/TestUtil/ProductVariantMockFactory.php
+++ b/src/TestUtil/ProductVariantMockFactory.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslation\PropertyGroupOptionTranslationCollection;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslation\PropertyGroupOptionTranslationEntity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupTranslation\PropertyGroupTranslationCollection;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupTranslation\PropertyGroupTranslationEntity;
+use Shopware\Core\Content\Property\PropertyGroupEntity;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+class ProductVariantMockFactory
+{
+    public function create(
+        ProductEntity $parent,
+        array $data = []
+    ): ProductEntity {
+        $variant  = new ProductEntity();
+        $size     = $data['size'] ?? 'S';
+        $color    = $data['color'] ?? 'red';
+        $material = $data['material'] ?? 'cotton';
+        $variant->setParent($parent);
+        $variant->setProductNumber($data['productNumber'] ?? 'SW100.1');
+        $variant->setId($data['id'] ?? Uuid::randomHex());
+        $variant->setParentId($parent->getId());
+        $variant->setOptions($data['options'] ?? self::createPropertyGroupOptionCollection(
+            [
+                [md5('size'), md5($size), 'size', $size],
+                [md5('color'), md5($color), 'color', $color],
+                [md5('material'), md5($material), 'material', $material],
+            ]
+        ));
+
+        return $variant;
+    }
+
+    /**
+     * $optionsConfig in format
+     *  [['groupId','optionId', 'groupName', 'optionName']].
+     *
+     * @param array $optionsConfig
+     *
+     * @return PropertyGroupOptionCollection
+     */
+    public static function createPropertyGroupOptionCollection(array $optionsConfig): PropertyGroupOptionCollection
+    {
+        $options    = array_reduce($optionsConfig, function (array $carriedOptions, array $optionConfig): array {
+            list($groupId, $optionId, $groupName, $optionName) = $optionConfig;
+            $group = new PropertyGroupEntity();
+            $group->setId($groupId);
+
+            $groupTranslation = new PropertyGroupTranslationEntity();
+            $groupTranslation->setPropertyGroupId(md5($groupId));
+            $groupTranslation->setName($groupName);
+            $groupTranslation->setUniqueIdentifier(Uuid::randomHex());
+
+            $group->setTranslations(new PropertyGroupTranslationCollection([md5($groupName) => $groupTranslation]));
+            $group->addTranslated('name', $groupName);
+
+            $option = new PropertyGroupOptionEntity();
+            $option->setId($optionId);
+
+            $optionTranslation = new PropertyGroupOptionTranslationEntity();
+            $optionTranslation->setPropertyGroupOptionId(md5($optionName));
+            $optionTranslation->setName($optionName);
+            $optionTranslation->setUniqueIdentifier(Uuid::randomHex());
+
+            $option->setTranslations(new PropertyGroupOptionTranslationCollection([md5($optionName) => $optionTranslation]));
+            $option->addTranslated('name', $optionName);
+            $option->setGroupId($groupId);
+            $option->setGroup($group);
+
+            return array_merge($carriedOptions, [$optionId => $option]);
+        }, []);
+
+        return new PropertyGroupOptionCollection($options);
+    }
+}

--- a/src/TestUtil/SalesChannelProductMockFactory.php
+++ b/src/TestUtil/SalesChannelProductMockFactory.php
@@ -14,9 +14,15 @@ class SalesChannelProductMockFactory
         $entity = new SalesChannelProductEntity();
         $entity->setId($product->getId());
         $entity->setProductNumber($product->getProductNumber());
-        $entity->setParent($product->getParent());
         $entity->setParentId($product->getParentId());
-        $entity->setOptions($product->getOptions());
+
+        if ($product->getParent() !== null) {
+            $entity->setOptions($product->getOptions());
+        }
+
+        if ($product->getParent() !== null) {
+            $entity->setParent($product->getParent());
+        }
 
         return $entity;
     }

--- a/src/TestUtil/SalesChannelProductMockFactory.php
+++ b/src/TestUtil/SalesChannelProductMockFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\TestUtil;
+
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+
+class SalesChannelProductMockFactory
+{
+    public function create(ProductEntity $product): SalesChannelProductEntity
+    {
+        $entity = new SalesChannelProductEntity();
+        $entity->setId($product->getId());
+        $entity->setProductNumber($product->getProductNumber());
+        $entity->setParent($product->getParent());
+        $entity->setParentId($product->getParentId());
+        $entity->setOptions($product->getOptions());
+
+        return $entity;
+    }
+}


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2539
- Description:
  - Adds cache mechanism that holds preprocessed product rows inside the database table. Also it takes products Storefront presentation configuration into consideration
- Tested with Shopware6 editions/versions: 
  - 6.4.9999999.9999999 Developer Version
- Tested with PHP versions: 
  - 7.4