### PR TITLE
FFWEB-2641: fix missing server url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Add
 - Add option to switch between Api Version
 
+### Fix
+- ClientBuilderConfigurator
+  - Fix problem with missing server URL when SDK is activated for first time
+
 ## [v4.0.4] - 2022.12.02
 ### Fix
 - Fix problem with missing page in ConfigurationSubscriber

--- a/src/Communication/ClientBuilderConfigurator.php
+++ b/src/Communication/ClientBuilderConfigurator.php
@@ -20,6 +20,9 @@ class ClientBuilderConfigurator
     public function configure(ClientBuilder $clientBuilder): void
     {
         $clientBuilder->withCredentials(new Credentials(...$this->config->getCredentials()));
-        $clientBuilder->withServerUrl($this->config->getServerUrl());
+
+        if ($this->config->getServerUrl() !== '') {
+            $clientBuilder->withServerUrl($this->config->getServerUrl());
+        }
     }
 }


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2641
- Description:
  - Fix problem with missing server URL when SDK is activated for first time
- Tested with Shopware6 editions/versions: 
  - 6.4.9999999.9999999 Developer Version
- Tested with PHP versions: 
  - 7.4