### PR TITLE
#117 - query parameter "p" must be translated to "page"

### DIFF
--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -75,6 +75,11 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         $params = (string) parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY);
 
         if ($params !== '') {
+            if (strpos($params, 'p=') === 0) {
+                $params = 'page=' . substr($params, 2);
+            } else {
+                $params = str_replace('&p=', '&page=', $params);
+            }
             $paramsString = sprintf('%s&%s', $params, $categoryPath);
         }
 


### PR DESCRIPTION
URL query parameter "p" must be translated to "page" for search against FF backend
