### PR TITLE
#121 $defaultFields overwrite $fields, so filterAttributes are empty …

### DIFF
--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -108,7 +108,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 
         return array_reduce(
             $fields,
-            fn (array $fields, FieldInterface $field): array => $fields + [$field->getName() => ($this->getAdditionalCache($field->getName()) ?? $field->getValue($isVariant ? $this->parent : $this->product))],
+            fn (array $fields, FieldInterface $field): array => [$field->getName() => ($this->getAdditionalCache($field->getName()) ?? $field->getValue($isVariant ? $this->parent : $this->product))] + $fields,
             $defaultFields
         );
     }


### PR DESCRIPTION
…in export

array on the left-hand "wins" over the array on the right-hand when using array-plus-operator

- Solves issue: 
- Description: 
- Tested with Shopware6 editions/versions: 
- Tested with PHP versions: 

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
