### PR TITLE
#120 Uncaught PHP Exception Error: "Call to a member function getId()…

### DIFF
--- a/src/Subscriber/BeforeSendResponseEventSubscriber.php
+++ b/src/Subscriber/BeforeSendResponseEventSubscriber.php
@@ -98,7 +98,10 @@ class BeforeSendResponseEventSubscriber implements EventSubscriberInterface
 
             if ($session->get(self::HAS_JUST_LOGGED_IN, false) === true) {
                 $response->headers->setCookie($this->getCookie(self::HAS_JUST_LOGGED_IN, '1'));
-                $response->headers->setCookie($this->getCookie(self::USER_ID, $response->getContext()->getCustomer()->getId()));
+                $customer = $response->getContext()->getCustomer();
+                if ($customer !== null) {
+                    $response->headers->setCookie($this->getCookie(self::USER_ID, $customer->getId()));
+                }
                 $session->set(self::HAS_JUST_LOGGED_IN, false);
             }
 


### PR DESCRIPTION
… on null" at vendor/omikron/shopware6-factfinder/src/Subscriber/BeforeSendResponseEventSubscriber.php line 101

- Solves issue: 
- Description: 
- Tested with Shopware6 editions/versions: 
- Tested with PHP versions: 

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
