### PR TITLE
FFWEB-2524: SSR improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 ### Add
 - Tracking
     - Add option to select scenario when `Add To Cart button` has been clicked
+### Change
+- SSR
+  - read fieldRoles using service and set default configuration as backup
+  - set SalesChannelId
+  - display navigation results when HTTP cache is enabled
+  - Fixed Uncaught TypeError: can't access property "find", t.path is undefined
+  - Replace FF_SEARCH_RESULT with empty string when page don't have to SSR
+  - add support for Mustache template engine
+  - set RequestStack as optional to avid fails for CLI-Commands
+  - combine masterValues with variantValues in search results
+  - prevent error when invalid chanel is set
+  - pass all parameters for category pages and search result
+  - translate query parameter "p" to "page"
+  - add SEO urls and link-rel-prev/next for pagination
+### Fix
+- SSR
+  - BeforeSendResponseEventSubscriber - fix Call to a member function getId() on null
+  - solve problem with empty filterAttributes in export
 
 ## [v4.1.0] - 2023.01.05
 ### Add

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "shopware/storefront": "^6.4",
     "league/flysystem-sftp": "1.0.22",
     "php": "^7.4 || ^8.0",
-    "ext-json": "*"
+    "ext-json": "*",
+    "mustache/mustache": "^2.14"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "3.1",

--- a/spec/Storefront/Controller/ResultControllerSpec.php
+++ b/spec/Storefront/Controller/ResultControllerSpec.php
@@ -6,6 +6,7 @@ namespace spec\Omikron\FactFinder\Shopware6\Storefront\Controller;
 
 use Omikron\FactFinder\Shopware6\Config\Communication;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
+use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Engine;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Wrapper\Collaborator;
 use Prophecy\Argument;
@@ -48,7 +49,6 @@ class ResultControllerSpec extends ObjectBehavior
         SystemConfigService $systemConfigService,
         Environment $twig,
         SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler
-
     ) {
         $this->request = $request;
         $this->config = $config;
@@ -75,7 +75,8 @@ class ResultControllerSpec extends ObjectBehavior
 
     public function it_should_return_original_response_content_when_ssr_is_not_active(
         SearchAdapter $searchAdapter,
-        Page $page
+        Page $page,
+        Engine $mustache
     ) {
         $content = 'original content';
         $this->pageLoader->load($this->request, $this->salesChannelContext)->willReturn($page);
@@ -85,7 +86,8 @@ class ResultControllerSpec extends ObjectBehavior
         $response = $this->result(
             $this->request,
             $this->salesChannelContext,
-            $searchAdapter
+            $searchAdapter,
+            $mustache
         );
 
         $response->shouldBeAnInstanceOf(Response::class);

--- a/src/Config/FieldRoles.php
+++ b/src/Config/FieldRoles.php
@@ -23,8 +23,13 @@ class FieldRoles
 
     public function getRoles(?string $salesChannelId): array
     {
-        $searchResult = $this->search->search($this->communicationConfig->getChannel($salesChannelId), '*');
-        $fieldRoles   = $searchResult['fieldRoles'] ?? [];
+        try {
+            $searchResult = $this->search->search($this->communicationConfig->getChannel($salesChannelId), '*');
+            $fieldRoles   = $searchResult['fieldRoles'] ?? [];
+        } catch (\Exception $e) {
+            $fieldRoles = [];
+        }
+
         return $this->map($fieldRoles);
     }
 

--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -108,7 +108,10 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
 
         return array_reduce(
             $fields,
-            fn (array $fields, FieldInterface $field): array => $fields + [$field->getName() => ($this->getAdditionalCache($field->getName()) ?? $field->getValue($isVariant ? $this->parent : $this->product))],
+            fn (array $fields, FieldInterface $field): array => array_merge(
+                $fields,
+                [$field->getName() => ($this->getAdditionalCache($field->getName()) ?? $field->getValue($isVariant ? $this->parent : $this->product))]
+            ),
             $defaultFields
         );
     }

--- a/src/Resources/app/storefront/src/plugin/asn-plugin.js
+++ b/src/Resources/app/storefront/src/plugin/asn-plugin.js
@@ -18,7 +18,7 @@ export default class AsnPlugin extends Plugin
         }
 
         const isAsnGroup = e => {
-             return e.path.find(p => p.tagName === 'ff-asn-group'.toUpperCase());
+            return this._eventPath(e).find(p => p.tagName === 'ff-asn-group'.toUpperCase());
         }
 
         if (!isAsnGroup(event)) {
@@ -32,6 +32,34 @@ export default class AsnPlugin extends Plugin
                 if (g.opened) g.toggle(true);
             })
         }
+    }
+
+    _eventPath(evt) {
+        var path = (evt.composedPath && evt.composedPath()) || evt.path,
+            target = evt.target;
+
+        if (path != null) {
+            // Safari doesn't include Window, but it should.
+            return (path.indexOf(window) < 0) ? path.concat(window) : path;
+        }
+
+        if (target === window) {
+            return [window];
+        }
+
+        function getParents(node, memo) {
+            memo = memo || [];
+            var parentNode = node.parentNode;
+
+            if (!parentNode) {
+                return memo;
+            }
+            else {
+                return getParents(parentNode, memo.concat(parentNode));
+            }
+        }
+
+        return [target].concat(getParents(target), window);
     }
 }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -48,8 +48,10 @@
             <parameter key="variant_cover">children.media</parameter>
         </parameter>
         <parameter key="factfinder.navigation.category_path_field_name" type="string">CategoryPath</parameter>
-        <parameter key="factfinder.category_page.add_params" type="collection"></parameter>
-        <parameter key="factfinder.configuration.add_params" type="collection"></parameter>
+        <parameter key="factfinder.category_page.add_params" type="collection">
+        </parameter>
+        <parameter key="factfinder.configuration.add_params" type="collection">
+        </parameter>
         <parameter key="factfinder.data_export.entity_type_map" type="collection">
         </parameter>
     </parameters>
@@ -170,5 +172,15 @@
         <service id="Omikron\FactFinder\Shopware6\Subscriber\FeedPreprocessorEntrySubscriber">
             <argument type="service" id="product.repository"/>
         </service>
+
+        <service id="Mustache_Engine" alias="factfinder.mustache_engine" />
+        <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\StringLoader" />
+        <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Filter" />
+        <service id="Mustache_Loader_StringLoader" alias="factfinder.mustache_loader_string_loader" />
+        <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Loader">
+            <argument type="service" id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\StringLoader"/>
+            <argument type="service" id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Filter"/>
+        </service>
+        <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Engine" />
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -105,6 +105,11 @@
             <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\CategoryRoute"/>
         </service>
 
+        <service id="Omikron\FactFinder\Shopware6\Subscriber\CategoryPageResponseSubscriber">
+            <argument>%shopware.http.cache.enabled%</argument>
+            <argument type="service" id="category.repository" />
+        </service>
+
         <service id="Omikron\FactFinder\Shopware6\Export\ExportCmsPages">
             <argument type="service" id="sales_channel.category.repository" />
         </service>
@@ -145,6 +150,7 @@
         </service>
         <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\PriceFormatter" />
         <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter" />
+        <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Field\CategoryPath" />
 
         <service id="Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntryDefinition">
             <tag name="shopware.entity.definition" entity="factfinder_feed_preprocessor" /></service>

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -37,11 +37,8 @@
     document.addEventListener('ffCommunicationReady', ({ factfinder, searchImmediate }) => {
       {% if page.extensions.factfinder.ssr == 'ssr' %}
         const searchResult = {FF_SEARCH_RESULT};
-
-        if (searchResult !== '') {
-          factfinder.communication.EventAggregator.currentSearchResult = searchResult;
-          factfinder.communication.ResultDispatcher.dispatchRaw(searchResult);
-        }
+        factfinder.communication.EventAggregator.currentSearchResult = searchResult;
+        factfinder.communication.ResultDispatcher.dispatchRaw(searchResult);
       {% endif %}
 
       const cookies = document.cookie.split('; ').reduce((acc, cookie) => {

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -37,8 +37,11 @@
     document.addEventListener('ffCommunicationReady', ({ factfinder, searchImmediate }) => {
       {% if page.extensions.factfinder.ssr == 'ssr' %}
         const searchResult = {FF_SEARCH_RESULT};
-        factfinder.communication.EventAggregator.currentSearchResult = searchResult;
-        factfinder.communication.ResultDispatcher.dispatchRaw(searchResult);
+
+        if (searchResult !== '') {
+          factfinder.communication.EventAggregator.currentSearchResult = searchResult;
+          factfinder.communication.ResultDispatcher.dispatchRaw(searchResult);
+        }
       {% endif %}
 
       const cookies = document.cookie.split('; ').reduce((acc, cookie) => {

--- a/src/Storefront/Controller/ResultController.php
+++ b/src/Storefront/Controller/ResultController.php
@@ -6,6 +6,7 @@ namespace Omikron\FactFinder\Shopware6\Storefront\Controller;
 
 use Omikron\FactFinder\Shopware6\Config\Communication;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
+use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Engine;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\RecordList;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -37,7 +38,8 @@ class ResultController extends StorefrontController
     public function result(
         Request $request,
         SalesChannelContext $context,
-        SearchAdapter $searchAdapter
+        SearchAdapter $searchAdapter,
+        Engine $mustache
     ): Response {
         $page     = $this->pageLoader->load($request, $context);
         $response = $this->renderStorefront('@Parent/storefront/page/factfinder/result.html.twig', ['page' => $page]);
@@ -47,7 +49,7 @@ class ResultController extends StorefrontController
         }
 
         $recordList = new RecordList(
-            $this->container->get('twig'),
+            $mustache,
             $searchAdapter,
             $context->getSalesChannelId(),
             $response->getContent(),

--- a/src/Storefront/Controller/ResultController.php
+++ b/src/Storefront/Controller/ResultController.php
@@ -49,6 +49,7 @@ class ResultController extends StorefrontController
         $recordList = new RecordList(
             $this->container->get('twig'),
             $searchAdapter,
+            $context->getSalesChannelId(),
             $response->getContent(),
         );
         $query = $request->query->get('query', '');

--- a/src/Storefront/Controller/ResultController.php
+++ b/src/Storefront/Controller/ResultController.php
@@ -54,10 +54,9 @@ class ResultController extends StorefrontController
             $context->getSalesChannelId(),
             $response->getContent(),
         );
-        $query = $request->query->get('query', '');
         $response->setContent(
             $recordList->getContent(
-                $query !== '' ? sprintf('query=%s', $query) : ''
+                (string) parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY)
             )
         );
 

--- a/src/Storefront/Controller/ResultController.php
+++ b/src/Storefront/Controller/ResultController.php
@@ -34,6 +34,8 @@ class ResultController extends StorefrontController
 
     /**
      * @Route(path="/factfinder/result", name="frontend.factfinder.result", methods={"GET"})
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
      */
     public function result(
         Request $request,

--- a/src/Storefront/Controller/ResultController.php
+++ b/src/Storefront/Controller/ResultController.php
@@ -49,6 +49,7 @@ class ResultController extends StorefrontController
         }
 
         $recordList = new RecordList(
+            $request,
             $mustache,
             $searchAdapter,
             $context->getSalesChannelId(),

--- a/src/Subscriber/BeforeSendResponseEventSubscriber.php
+++ b/src/Subscriber/BeforeSendResponseEventSubscriber.php
@@ -85,14 +85,15 @@ class BeforeSendResponseEventSubscriber implements EventSubscriberInterface
         }
 
         $response = $event->getResponse();
-        $context = $response->getContext();
 
         if (
             method_exists($response, 'getContext') === false
-            || $context === null
+            || $response->getContext() === null
         ) {
             return false;
         }
+
+        $context = $response->getContext();
 
         try {
             $this->validateRequest($request, $response);

--- a/src/Subscriber/BeforeSendResponseEventSubscriber.php
+++ b/src/Subscriber/BeforeSendResponseEventSubscriber.php
@@ -85,10 +85,11 @@ class BeforeSendResponseEventSubscriber implements EventSubscriberInterface
         }
 
         $response = $event->getResponse();
+        $context = $response->getContext();
 
         if (
             method_exists($response, 'getContext') === false
-            || $response->getContext() === null
+            || $context === null
         ) {
             return false;
         }
@@ -96,9 +97,13 @@ class BeforeSendResponseEventSubscriber implements EventSubscriberInterface
         try {
             $this->validateRequest($request, $response);
 
+            if ($context->getCustomer() === null) {
+                return false;
+            }
+
             if ($session->get(self::HAS_JUST_LOGGED_IN, false) === true) {
                 $response->headers->setCookie($this->getCookie(self::HAS_JUST_LOGGED_IN, '1'));
-                $response->headers->setCookie($this->getCookie(self::USER_ID, $response->getContext()->getCustomer()->getId()));
+                $response->headers->setCookie($this->getCookie(self::USER_ID, $context->getCustomer()->getId()));
                 $session->set(self::HAS_JUST_LOGGED_IN, false);
             }
 

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -71,9 +71,16 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
             $request->attributes->get('sw-sales-channel-id'),
             $response->getContent(),
         );
+        $paramsString = $categoryPath;
+        $params = (string) parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY);
+
+        if ($params !== '') {
+            $paramsString = sprintf('%s&%s', $params, $categoryPath);
+        }
+
         $response->setContent(
             $recordList->getContent(
-                $categoryPath,
+                $paramsString,
                 true
             )
         );

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -7,6 +7,7 @@ namespace Omikron\FactFinder\Shopware6\Subscriber;
 use Omikron\FactFinder\Shopware6\Config\Communication;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Field\CategoryPath;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
+use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Engine;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\RecordList;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
@@ -15,7 +16,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Event\BeforeSendResponseEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Twig\Environment;
 
 class CategoryPageResponseSubscriber implements EventSubscriberInterface
 {
@@ -23,7 +23,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
     private EntityRepositoryInterface $categoryRepository;
     private Communication $config;
     private SearchAdapter $searchAdapter;
-    private Environment $twig;
+    private Engine $mustache;
     private CategoryPath $categoryPath;
 
     public function __construct(
@@ -31,14 +31,14 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         EntityRepositoryInterface $categoryRepository,
         Communication $config,
         SearchAdapter $searchAdapter,
-        Environment $twig,
+        Engine $mustache,
         CategoryPath $categoryPath
     ) {
         $this->httpCacheEnabled   = $httpCacheEnabled;
         $this->categoryRepository = $categoryRepository;
         $this->config             = $config;
         $this->searchAdapter      = $searchAdapter;
-        $this->twig               = $twig;
+        $this->mustache               = $mustache;
         $this->categoryPath       = $categoryPath;
     }
 
@@ -66,7 +66,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         }
 
         $recordList = new RecordList(
-            $this->twig,
+            $this->mustache,
             $this->searchAdapter,
             $request->attributes->get('sw-sales-channel-id'),
             $response->getContent(),

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -74,6 +74,11 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         $params = (string) parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY);
 
         if ($params !== '') {
+            if (strpos($params, 'p=') === 0) {
+                $params = 'page=' . substr($params, 2);
+            } else {
+                $params = str_replace('&p=', '&page=', $params);
+            }
             $paramsString = sprintf('%s&%s', $params, $categoryPath);
         }
 

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -102,7 +102,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
     {
         $uri = $request->attributes->get('resolved-uri');
         $start = '/navigation/';
-        $pos = strpos($uri, $start);
+        $pos = strpos($uri ?? '', $start);
 
         if ($pos !== 0) {
             return '';

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -65,6 +65,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         }
 
         $recordList = new RecordList(
+            $request,
             $this->mustache,
             $this->searchAdapter,
             $request->attributes->get('sw-sales-channel-id'),
@@ -85,10 +86,6 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         if ($params === '') {
             return $categoryPath;
         }
-
-        $params = strpos($params, 'p=') === 0
-            ? sprintf('page=%s', substr($params, 2))
-            : str_replace('&p=', '&page=', $params);
 
         return sprintf('%s&%s', $params, $categoryPath);
     }

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -51,6 +51,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         $recordList = new RecordList(
             $this->twig,
             $this->searchAdapter,
+            $request->attributes->get('sw-sales-channel-id'),
             $response->getContent(),
         );
         $response->setContent(

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -54,14 +54,13 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         $request      = $event->getRequest();
         $response     = $event->getResponse();
         $categoryPath = $this->getCategoryPath($request);
+        $response->setContent(str_replace('{FF_SEARCH_RESULT}', json_encode([]), $response->getContent()));
 
         if (
             $this->config->isSsrActive() === false
             || $request->isXmlHttpRequest()
             || $categoryPath === ''
         ) {
-            $response->setContent(str_replace('{FF_SEARCH_RESULT}', '', $response->getContent()));
-
             return;
         }
 

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -34,12 +34,12 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         Engine $mustache,
         CategoryPath $categoryPath
     ) {
-        $this->httpCacheEnabled   = $httpCacheEnabled;
-        $this->categoryRepository = $categoryRepository;
-        $this->config             = $config;
-        $this->searchAdapter      = $searchAdapter;
+        $this->httpCacheEnabled       = $httpCacheEnabled;
+        $this->categoryRepository     = $categoryRepository;
+        $this->config                 = $config;
+        $this->searchAdapter          = $searchAdapter;
         $this->mustache               = $mustache;
-        $this->categoryPath       = $categoryPath;
+        $this->categoryPath           = $categoryPath;
     }
 
     public static function getSubscribedEvents()
@@ -111,9 +111,9 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
 
     private function getCategoryId(Request $request): string
     {
-        $uri = $request->attributes->get('resolved-uri');
+        $uri   = $request->attributes->get('resolved-uri');
         $start = '/navigation/';
-        $pos = strpos($uri ?? '', $start);
+        $pos   = strpos($uri ?? '', $start);
 
         if ($pos !== 0) {
             return '';

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -70,24 +70,27 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
             $request->attributes->get('sw-sales-channel-id'),
             $response->getContent(),
         );
-        $paramsString = $categoryPath;
-        $params = (string) parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY);
-
-        if ($params !== '') {
-            if (strpos($params, 'p=') === 0) {
-                $params = 'page=' . substr($params, 2);
-            } else {
-                $params = str_replace('&p=', '&page=', $params);
-            }
-            $paramsString = sprintf('%s&%s', $params, $categoryPath);
-        }
-
         $response->setContent(
             $recordList->getContent(
-                $paramsString,
+                $this->getParamsString($categoryPath),
                 true
             )
         );
+    }
+
+    private function getParamsString(string $categoryPath): string
+    {
+        $params = (string) parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY);
+
+        if ($params === '') {
+            return $categoryPath;
+        }
+
+        $params = strpos($params, 'p=') === 0
+            ? sprintf('page=%s', substr($params, 2))
+            : str_replace('&p=', '&page=', $params);
+
+        return sprintf('%s&%s', $params, $categoryPath);
     }
 
     private function getCategoryPath(Request $request): string

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Subscriber;
 
+use Exception;
 use Omikron\FactFinder\Shopware6\Config\Communication;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\RecordList;
@@ -36,8 +37,13 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
 
     public function onPageRendered(BeforeSendResponseEvent $event): void
     {
-        $request      = $event->getRequest();
-        $categoryPath = $request->attributes->get('categoryPath', '');
+        $request = $event->getRequest();
+
+        try {
+            $categoryPath = $request->getSession()->get(CategoryPageSubscriber::CATEGORY_PATH, '');
+        } catch (Exception $e) {
+            $categoryPath = '';
+        }
 
         if (
             $this->config->isSsrActive() === false

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -79,6 +79,9 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         );
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.Superglobals)
+     */
     private function getParamsString(string $categoryPath): string
     {
         $params = (string) parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY);
@@ -90,6 +93,9 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         return sprintf('%s&%s', $params, $categoryPath);
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
     private function getCategoryPath(Request $request): string
     {
         $categoryId = $this->getCategoryId($request);

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -37,7 +37,8 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
 
     public function onPageRendered(BeforeSendResponseEvent $event): void
     {
-        $request = $event->getRequest();
+        $request  = $event->getRequest();
+        $response = $event->getResponse();
 
         try {
             $categoryPath = $request->getSession()->get(CategoryPageSubscriber::CATEGORY_PATH, '');
@@ -50,10 +51,11 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
             || $request->isXmlHttpRequest()
             || $categoryPath === ''
         ) {
+            $response->setContent(str_replace('{FF_SEARCH_RESULT}', '', $response->getContent()));
+
             return;
         }
 
-        $response   = $event->getResponse();
         $recordList = new RecordList(
             $this->twig,
             $this->searchAdapter,

--- a/src/Subscriber/ConfigurationSubscriber.php
+++ b/src/Subscriber/ConfigurationSubscriber.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Storefront\Event\StorefrontRenderEvent;
 use Shopware\Storefront\Page\GenericPageLoadedEvent;
-use Shopware\Storefront\Page\Page;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ConfigurationSubscriber implements EventSubscriberInterface

--- a/src/Subscriber/ConfigurationSubscriber.php
+++ b/src/Subscriber/ConfigurationSubscriber.php
@@ -8,6 +8,7 @@ use Exception;
 use Omikron\FactFinder\Shopware6\Config\Communication;
 use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Storefront\Event\StorefrontRenderEvent;
 use Shopware\Storefront\Page\GenericPageLoadedEvent;
 use Shopware\Storefront\Page\Page;
@@ -75,7 +76,7 @@ class ConfigurationSubscriber implements EventSubscriberInterface
         }
     }
 
-    private function getPage(ShopwareSalesChannelEvent $event): Page
+    private function getPage(ShopwareSalesChannelEvent $event): Struct
     {
         if (method_exists($event, 'getPage')) {
             return $event->getPage();
@@ -83,7 +84,10 @@ class ConfigurationSubscriber implements EventSubscriberInterface
 
         $parameters = method_exists($event, 'getParameters') && is_array($event->getParameters()) ? $event->getParameters() : [];
 
-        if (isset($parameters['page'])) {
+        if (
+            isset($parameters['page'])
+            && $parameters['page'] instanceof Struct
+        ) {
             return $parameters['page'];
         }
 

--- a/src/Subscriber/CustomerLoginEventSubscriber.php
+++ b/src/Subscriber/CustomerLoginEventSubscriber.php
@@ -10,9 +10,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class CustomerLoginEventSubscriber implements EventSubscriberInterface
 {
-    private RequestStack $requestStack;
+    private ?RequestStack $requestStack;
 
-    public function __construct(RequestStack $requestStack)
+    public function __construct(?RequestStack $requestStack = null)
     {
         $this->requestStack = $requestStack;
     }
@@ -26,7 +26,9 @@ class CustomerLoginEventSubscriber implements EventSubscriberInterface
 
     public function hasJustLoggedIn(): void
     {
-        $session = $this->requestStack->getMainRequest()->getSession();
-        $session->set(BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN, true);
+        if (isset($this->requestStack)) {
+            $session = $this->requestStack->getMainRequest()->getSession();
+            $session->set(BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN, true);
+        }
     }
 }

--- a/src/Subscriber/CustomerLoginEventSubscriber.php
+++ b/src/Subscriber/CustomerLoginEventSubscriber.php
@@ -10,9 +10,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class CustomerLoginEventSubscriber implements EventSubscriberInterface
 {
-    private RequestStack $requestStack;
+    private ?RequestStack $requestStack;
 
-    public function __construct(RequestStack $requestStack)
+    public function __construct(?RequestStack $requestStack = null)
     {
         $this->requestStack = $requestStack;
     }
@@ -26,7 +26,10 @@ class CustomerLoginEventSubscriber implements EventSubscriberInterface
 
     public function hasJustLoggedIn(): void
     {
-        if ($this->requestStack->getMainRequest() === null) {
+        if (
+            !isset($this->requestStack)
+            || $this->requestStack->getMainRequest() === null
+        ) {
             return;
         }
 

--- a/src/Subscriber/CustomerLoginEventSubscriber.php
+++ b/src/Subscriber/CustomerLoginEventSubscriber.php
@@ -10,9 +10,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class CustomerLoginEventSubscriber implements EventSubscriberInterface
 {
-    private ?RequestStack $requestStack;
+    private RequestStack $requestStack;
 
-    public function __construct(?RequestStack $requestStack = null)
+    public function __construct(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
     }
@@ -26,9 +26,11 @@ class CustomerLoginEventSubscriber implements EventSubscriberInterface
 
     public function hasJustLoggedIn(): void
     {
-        if (isset($this->requestStack)) {
-            $session = $this->requestStack->getMainRequest()->getSession();
-            $session->set(BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN, true);
+        if ($this->requestStack->getMainRequest() === null) {
+            return;
         }
+
+        $session = $this->requestStack->getMainRequest()->getSession();
+        $session->set(BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN, true);
     }
 }

--- a/src/Subscriber/CustomerLogoutEventSubscriber.php
+++ b/src/Subscriber/CustomerLogoutEventSubscriber.php
@@ -10,9 +10,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class CustomerLogoutEventSubscriber implements EventSubscriberInterface
 {
-    private RequestStack $requestStack;
+    private ?RequestStack $requestStack;
 
-    public function __construct(RequestStack $requestStack)
+    public function __construct(?RequestStack $requestStack = null)
     {
         $this->requestStack = $requestStack;
     }
@@ -26,6 +26,13 @@ class CustomerLogoutEventSubscriber implements EventSubscriberInterface
 
     public function hasJustLoggedOut(): void
     {
+        if (
+            !isset($this->requestStack)
+            || $this->requestStack->getMainRequest() === null
+        ) {
+            return;
+        }
+
         $session = $this->requestStack->getMainRequest()->getSession();
         $session->set(BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_OUT, true);
     }

--- a/src/Utilites/Ssr/Field/CategoryPath.php
+++ b/src/Utilites/Ssr/Field/CategoryPath.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Field;
+
+use Shopware\Core\Content\Category\CategoryEntity;
+
+class CategoryPath
+{
+    private string $fieldName;
+
+    public function __construct(string $categoryPathFieldName)
+    {
+        $this->fieldName = $categoryPathFieldName;
+    }
+
+    public function getValue(CategoryEntity $categoryEntity): string
+    {
+        $categories   = array_slice($categoryEntity->getBreadcrumb(), 1);
+        $categoryPath = implode('/', array_map(fn ($category): string => $this->encodeCategoryName($category), $categories));
+
+        return sprintf('filter=%s', urlencode($this->fieldName . ':' . $categoryPath));
+    }
+
+    private function encodeCategoryName(string $path): string
+    {
+        //important! do not modify this method
+        return preg_replace('/\+/', '%2B', preg_replace('/\//', '%2F',
+            preg_replace('/%/', '%25', $path)));
+    }
+}

--- a/src/Utilites/Ssr/PriceFormatter.php
+++ b/src/Utilites/Ssr/PriceFormatter.php
@@ -42,7 +42,7 @@ class PriceFormatter
     {
         return function (array $record) use ($priceField): array {
             $record = $this->convertRecord($record);
-            $price = $record['masterValues'][$priceField] ?? '';
+            $price  = $record['masterValues'][$priceField] ?? '';
 
             if ($price === '') {
                 $record['record'] = $record['masterValues'];
@@ -89,7 +89,7 @@ class PriceFormatter
             return [];
         }
 
-        $keys = array_keys($variantValues);
+        $keys      = array_keys($variantValues);
         $masterKey = array_filter($keys, fn ($key) => $variantValues[$key]['isMaster'] ?? false === 'true')[0] ?? $keys[0] ?? null;
 
         if ($masterKey === null) {

--- a/src/Utilites/Ssr/PriceFormatter.php
+++ b/src/Utilites/Ssr/PriceFormatter.php
@@ -4,28 +4,35 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Utilites\Ssr;
 
+use Omikron\FactFinder\Shopware6\Config\FieldRoles;
 use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
 use Shopware\Core\System\Currency\CurrencyFormatter;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class PriceFormatter
 {
     private SalesChannelService $channelService;
+    private SalesChannelContext $context;
     private CurrencyFormatter $currencyFormatter;
     private array $fieldRoles;
+    private array $defaultFieldRoles;
 
     public function __construct(
         SalesChannelService $channelService,
         CurrencyFormatter $currencyFormatter,
+        FieldRoles $fieldRolesService,
         array $fieldRoles
     ) {
         $this->channelService    = $channelService;
         $this->currencyFormatter = $currencyFormatter;
-        $this->fieldRoles        = $fieldRoles;
+        $this->context           = $this->channelService->getSalesChannelContext();
+        $this->fieldRoles        = $fieldRolesService->getRoles($this->context->getSalesChannelId());
+        $this->defaultFieldRoles = $fieldRoles;
     }
 
     public function format(array $searchResult): array
     {
-        $priceField = $this->fieldRoles['price'] ?? 'Price';
+        $priceField = $this->getPriceField();
         $records    = $searchResult['hits'];
 
         return ['records' => array_map($this->price($priceField), $records)] + $searchResult;
@@ -34,7 +41,14 @@ class PriceFormatter
     protected function price(string $priceField): callable
     {
         return function (array $record) use ($priceField): array {
-            $price            = $record['masterValues'][$priceField];
+            $price = $record['masterValues'][$priceField] ?? '';
+
+            if ($price === '') {
+                $record['record'] = $record['masterValues'];
+
+                return $record;
+            }
+
             $record['record'] = [
                     '__ORIG_PRICE__' => $price,
                     $priceField      => $this->getFormattedPrice($price),
@@ -46,13 +60,16 @@ class PriceFormatter
 
     private function getFormattedPrice(float $price): string
     {
-        $context = $this->channelService->getSalesChannelContext();
-
         return $this->currencyFormatter->formatCurrencyByLanguage(
             $price,
-            $context->getCurrency()->getIsoCode(),
-            $context->getLanguageId(),
-            $context->getContext()
+            $this->context->getCurrency()->getIsoCode(),
+            $this->context->getLanguageId(),
+            $this->context->getContext()
         );
+    }
+
+    private function getPriceField(): string
+    {
+        return $this->fieldRoles['price'] ?? $this->defaultFieldRoles['price'] ?? 'Price';
     }
 }

--- a/src/Utilites/Ssr/PriceFormatter.php
+++ b/src/Utilites/Ssr/PriceFormatter.php
@@ -41,6 +41,7 @@ class PriceFormatter
     protected function price(string $priceField): callable
     {
         return function (array $record) use ($priceField): array {
+            $record = $this->convertRecord($record);
             $price = $record['masterValues'][$priceField] ?? '';
 
             if ($price === '') {
@@ -71,5 +72,30 @@ class PriceFormatter
     private function getPriceField(): string
     {
         return $this->fieldRoles['price'] ?? $this->defaultFieldRoles['price'] ?? 'Price';
+    }
+
+    private function convertRecord(array $record): array
+    {
+        $record['masterValues'] = array_merge($record['masterValues'], $this->getVariant($record));
+
+        return $record;
+    }
+
+    private function getVariant($record): array
+    {
+        $variantValues = $record['variantValues'] ?? [];
+
+        if ($variantValues === []) {
+            return [];
+        }
+
+        $keys = array_keys($variantValues);
+        $masterKey = array_filter($keys, fn ($key) => $variantValues[$key]['isMaster'] ?? false === 'true')[0] ?? $keys[0] ?? null;
+
+        if ($masterKey === null) {
+            return [];
+        }
+
+        return $variantValues[$masterKey] ?? [];
     }
 }

--- a/src/Utilites/Ssr/SearchAdapter.php
+++ b/src/Utilites/Ssr/SearchAdapter.php
@@ -26,15 +26,18 @@ class SearchAdapter
         $this->priceFormatter = $priceFormatter;
     }
 
-    public function search(string $paramString, bool $navigationRequest): array
-    {
+    public function search(
+        string $paramString,
+        bool $navigationRequest,
+        string $salesChannelId
+    ): array {
         $client = $this->clientBuilder
             ->withServerUrl($this->config->getServerUrl())
             ->withCredentials(new Credentials(...$this->config->getCredentials()))
             ->withVersion($this->config->getVersion())
             ->build();
 
-        $endpoint = $this->createEndpoint($paramString, $navigationRequest);
+        $endpoint = $this->createEndpoint($paramString, $navigationRequest, $salesChannelId);
         $response = $client->request('GET', $endpoint);
 
         if (!$response) {
@@ -49,11 +52,11 @@ class SearchAdapter
         return json_decode((string) $response->getBody(), true);
     }
 
-    private function createEndpoint(string $paramString, bool $navigationRequest)
+    private function createEndpoint(string $paramString, bool $navigationRequest, string $salesChannelId)
     {
-        $apiVersion  = $this->config->getApiVersion();
-        $channel     = $this->config->getChannel();
-        $endpoint    = $navigationRequest ? 'navigation' : 'search';
+        $apiVersion = $this->config->getApiVersion();
+        $channel    = $this->config->getChannel($salesChannelId);
+        $endpoint   = $navigationRequest ? 'navigation' : 'search';
 
         return "rest/{$apiVersion}/{$endpoint}/{$channel}?{$paramString}";
     }

--- a/src/Utilites/Ssr/Template/Engine.php
+++ b/src/Utilites/Ssr/Template/Engine.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
+
+use Mustache_Engine as Mustache;
+
+class Engine
+{
+    private Mustache $engine;
+
+    public function __construct(Loader $loader)
+    {
+        $this->engine = new Mustache(
+            [
+                'loader' => $loader,
+                'strict_callables' => true,
+            ]
+        );
+    }
+
+    public function render(
+        string $templateFile,
+        array $context = []
+    ): string {
+        return $this->engine->loadTemplate($templateFile)->render($context);
+    }
+}

--- a/src/Utilites/Ssr/Template/Engine.php
+++ b/src/Utilites/Ssr/Template/Engine.php
@@ -14,7 +14,7 @@ class Engine
     {
         $this->engine = new Mustache(
             [
-                'loader' => $loader,
+                'loader'           => $loader,
                 'strict_callables' => true,
             ]
         );

--- a/src/Utilites/Ssr/Template/Filter.php
+++ b/src/Utilites/Ssr/Template/Filter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
+
+use Omikron\FactFinder\Shopware6\Config\FieldRoles;
+use Omikron\FactFinder\Shopware6\Export\Filter\FilterInterface;
+use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
+
+class Filter implements FilterInterface
+{
+    private array $fieldRoles;
+
+    public function __construct(
+        SalesChannelService $channelService,
+        FieldRoles $fieldRolesService
+    ) {
+        $context          = $channelService->getSalesChannelContext();
+        $this->fieldRoles = $fieldRolesService->getRoles($context->getSalesChannelId());
+    }
+
+    public function filterValue(string $value): string
+    {
+        $value = preg_replace('#data-anchor="([^"]+?)"#', 'href="$1" $0', $value);
+        $value = preg_replace('#data-redirect-target="_(blank|self|parent|top)"#', 'target="_$1" $0', $value);
+        return preg_replace_callback('#data-image(?:="([^"]+?)")?#', function (array $match): string {
+            $imageField = $this->fieldRoles['imageUrl'];
+            return sprintf('src="%s" %s', $match[1] ?? "{{record.{$imageField}}}", $match[0]);
+        }, $value);
+    }
+}

--- a/src/Utilites/Ssr/Template/Loader.php
+++ b/src/Utilites/Ssr/Template/Loader.php
@@ -22,7 +22,7 @@ class Loader implements Mustache_Loader
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function load($name)
     {

--- a/src/Utilites/Ssr/Template/Loader.php
+++ b/src/Utilites/Ssr/Template/Loader.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
+
+use Mustache_Loader;
+use Mustache_Source;
+use Omikron\FactFinder\Shopware6\Export\Filter\FilterInterface;
+
+class Loader implements Mustache_Loader
+{
+    private Mustache_Loader $loader;
+    private FilterInterface $filter;
+
+    public function __construct(
+        Mustache_Loader $loader,
+        FilterInterface $filter
+    ) {
+        $this->loader = $loader;
+        $this->filter = $filter;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function load($name)
+    {
+        $template = $this->loader->load($name);
+        return $template instanceof Mustache_Source ? $template : $this->filter->filterValue($template);
+    }
+}

--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -48,7 +48,7 @@ class RecordList
             ''
         );
 
-        $this->content = str_replace('{FF_SEARCH_RESULT}', json_encode($results) ?: '', $this->content);
+        $this->content = str_replace('{FF_SEARCH_RESULT}', json_encode($results) ?: json_encode([]), $this->content);
 
         return preg_replace(self::SSR_RECORD_PATTERN, $recordsContent, $this->content);
     }

--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -5,26 +5,25 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
 
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
-use Twig\Environment;
 
 class RecordList
 {
     private const RECORD_PATTERN     = '#<ff-record[\s>].*?</ff-record>#s';
     private const SSR_RECORD_PATTERN = '#<ssr-record-template>.*?</ssr-record-template>#s';
 
-    private Environment $twig;
+    private Engine $mustache;
     private SearchAdapter $searchAdapter;
     private string $salesChannelId;
     private string $content;
     private string $template;
 
     public function __construct(
-        Environment $twig,
+        Engine $mustache,
         SearchAdapter $searchAdapter,
         string $salesChannelId,
         string $content
     ) {
-        $this->twig           = $twig;
+        $this->mustache       = $mustache;
         $this->searchAdapter  = $searchAdapter;
         $this->salesChannelId = $salesChannelId;
         $this->content        = $content;
@@ -39,13 +38,12 @@ class RecordList
         bool $isNavigationRequest = false
     ) {
         $results        = $this->searchAdapter->search($paramString, $isNavigationRequest, $this->salesChannelId);
-        $template       = $this->twig->createTemplate($this->template);
         $recordsContent = array_reduce(
             $results['records'] ?? [],
             fn (string $carry, array $record) => sprintf(
                 '%s%s',
                 $carry,
-                $template->render($record)
+                $this->mustache->render($this->template, $record)
             ),
             ''
         );

--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
 
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
+use Symfony\Component\HttpFoundation\Request;
 
 class RecordList
 {
     private const RECORD_PATTERN     = '#<ff-record[\s>].*?</ff-record>#s';
     private const SSR_RECORD_PATTERN = '#<ssr-record-template>.*?</ssr-record-template>#s';
 
+    private Request $request;
     private Engine $mustache;
     private SearchAdapter $searchAdapter;
     private string $salesChannelId;
@@ -18,11 +20,13 @@ class RecordList
     private string $template;
 
     public function __construct(
+        Request $request,
         Engine $mustache,
         SearchAdapter $searchAdapter,
         string $salesChannelId,
         string $content
     ) {
+        $this->request = $request;
         $this->mustache       = $mustache;
         $this->searchAdapter  = $searchAdapter;
         $this->salesChannelId = $salesChannelId;
@@ -37,6 +41,9 @@ class RecordList
         string $paramString,
         bool $isNavigationRequest = false
     ) {
+        $paramString = strpos($paramString, 'p=') === 0
+            ? sprintf('page=%s', substr($paramString, 2))
+            : str_replace('&p=', '&page=', $paramString);
         $results        = $this->searchAdapter->search($paramString, $isNavigationRequest, $this->salesChannelId);
         $recordsContent = array_reduce(
             $results['records'] ?? [],
@@ -49,8 +56,30 @@ class RecordList
         );
 
         $this->content = str_replace('{FF_SEARCH_RESULT}', json_encode($results) ?: json_encode([]), $this->content);
+        $this->setContentWithLinks($results, $paramString);
 
         return preg_replace(self::SSR_RECORD_PATTERN, $recordsContent, $this->content);
+    }
+
+    private function setContentWithLinks(array $results, string $paramString): void
+    {
+        $nextPage = $results['paging']['nextLink']['number'] ?? null;
+        $previousPage = $results['paging']['previousLink']['number'] ?? null;
+        $nextLink = '';
+        $previousLink = '';
+        $pos = strpos($this->request->getUri(), '?');
+        $baseUrl = $pos === false ? $this->request->getUri() : substr($this->request->getUri(), 0, $pos);
+        $params = array_filter(explode('&', $paramString), fn (string $param) => strpos($param, 'page=') !== 0);
+
+        if ($previousPage !== null) {
+            $previousLink = sprintf('<link rel="prev" href="%s?%s" />', $baseUrl, implode('&', [...$params, sprintf('page=%s', $previousPage)]));
+        }
+
+        if ($nextPage !== null) {
+            $nextLink = sprintf('<link rel="next" href="%s?%s" />', $baseUrl, implode('&', [...$params, sprintf('page=%s', $nextPage)]));
+        }
+
+        $this->content = str_replace('</head>', sprintf('%s%s</head>', $previousLink, $nextLink), $this->content);
     }
 
     private function setTemplateString(): void

--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -26,7 +26,7 @@ class RecordList
         string $salesChannelId,
         string $content
     ) {
-        $this->request = $request;
+        $this->request        = $request;
         $this->mustache       = $mustache;
         $this->searchAdapter  = $searchAdapter;
         $this->salesChannelId = $salesChannelId;
@@ -63,13 +63,13 @@ class RecordList
 
     private function setContentWithLinks(array $results, string $paramString): void
     {
-        $nextPage = $results['paging']['nextLink']['number'] ?? null;
+        $nextPage     = $results['paging']['nextLink']['number'] ?? null;
         $previousPage = $results['paging']['previousLink']['number'] ?? null;
-        $nextLink = '';
+        $nextLink     = '';
         $previousLink = '';
-        $pos = strpos($this->request->getUri(), '?');
-        $baseUrl = $pos === false ? $this->request->getUri() : substr($this->request->getUri(), 0, $pos);
-        $params = array_filter(explode('&', $paramString), fn (string $param) => strpos($param, 'page=') !== 0);
+        $pos          = strpos($this->request->getUri(), '?');
+        $baseUrl      = $pos === false ? $this->request->getUri() : substr($this->request->getUri(), 0, $pos);
+        $params       = array_filter(explode('&', $paramString), fn (string $param) => strpos($param, 'page=') !== 0);
 
         if ($previousPage !== null) {
             $previousLink = sprintf('<link rel="prev" href="%s?%s" />', $baseUrl, implode('&', [...$params, sprintf('page=%s', $previousPage)]));

--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -14,17 +14,20 @@ class RecordList
 
     private Environment $twig;
     private SearchAdapter $searchAdapter;
+    private string $salesChannelId;
     private string $content;
     private string $template;
 
     public function __construct(
         Environment $twig,
         SearchAdapter $searchAdapter,
+        string $salesChannelId,
         string $content
     ) {
-        $this->twig          = $twig;
-        $this->searchAdapter = $searchAdapter;
-        $this->content       = $content;
+        $this->twig           = $twig;
+        $this->searchAdapter  = $searchAdapter;
+        $this->salesChannelId = $salesChannelId;
+        $this->content        = $content;
         $this->setTemplateString();
     }
 
@@ -35,7 +38,7 @@ class RecordList
         string $paramString,
         bool $isNavigationRequest = false
     ) {
-        $results        = $this->searchAdapter->search($paramString, $isNavigationRequest);
+        $results        = $this->searchAdapter->search($paramString, $isNavigationRequest, $this->salesChannelId);
         $template       = $this->twig->createTemplate($this->template);
         $recordsContent = array_reduce(
             $results['records'] ?? [],

--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -43,7 +43,7 @@ class RecordList
             fn (string $carry, array $record) => sprintf(
                 '%s%s',
                 $carry,
-                $this->mustache->render($this->template, $this->convertRecord($record))
+                $this->mustache->render($this->template, $record)
             ),
             ''
         );
@@ -51,31 +51,6 @@ class RecordList
         $this->content = str_replace('{FF_SEARCH_RESULT}', json_encode($results) ?: '', $this->content);
 
         return preg_replace(self::SSR_RECORD_PATTERN, $recordsContent, $this->content);
-    }
-
-    private function convertRecord(array $record): array
-    {
-        $record['masterValues'] = array_merge($record['masterValues'], $this->getVariant($record));
-
-        return $record;
-    }
-
-    private function getVariant($record): array
-    {
-        $variantValues = $record['variantValues'] ?? [];
-
-        if ($variantValues === []) {
-            return [];
-        }
-
-        $keys = array_keys($variantValues);
-        $masterKey = array_filter($keys, fn ($key) => $variantValues[$key]['isMaster'] ?? false === 'true')[0] ?? $keys[0] ?? null;
-
-        if ($masterKey === null) {
-            return [];
-        }
-
-        return $variantValues[$masterKey] ?? [];
     }
 
     private function setTemplateString(): void

--- a/src/Utilites/Ssr/Template/StringLoader.php
+++ b/src/Utilites/Ssr/Template/StringLoader.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
+
+use Mustache_Loader_StringLoader;
+
+class StringLoader extends Mustache_Loader_StringLoader
+{
+}


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2524
  - FFWEB-2647
- Description:
  - SSR
    - read fieldRoles using service and set default configuration as backup
    - set SalesChannelId
    - display navigation results when HTTP cache is enabled
    - Fixed Uncaught TypeError: can't access property "find", t.path is undefined
    - Replace FF_SEARCH_RESULT with empty string when page don't have to SSR
    - add support for Mustache template engine
    - set RequestStack as optional to avid fails for CLI-Commands
    - combine masterValues with variantValues in search results
    - prevent error when invalid chanel is set
    - pass all parameters for category pages and search result
    - query parameter "p" must be translated to "page"
    - add SEO urls and link-rel-prev/next for pagination
    - BeforeSendResponseEventSubscriber - fix Call to a member function getId() on null
    - solve problem with empty filterAttributes in export
- Tested with Shopware6 editions/versions: 
  - 6.4.9999999.9999999 Developer Version
- Tested with PHP versions: 
  - 7.4