### PR TITLE
#126 - only replace FF_SEARCH_RESULT if no real result will be rendered

### DIFF
--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -54,13 +54,13 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         $request      = $event->getRequest();
         $response     = $event->getResponse();
         $categoryPath = $this->getCategoryPath($request);
-        $response->setContent(str_replace('{FF_SEARCH_RESULT}', json_encode([]), $response->getContent()));
 
         if (
             $this->config->isSsrActive() === false
             || $request->isXmlHttpRequest()
             || $categoryPath === ''
         ) {
+            $response->setContent(str_replace('{FF_SEARCH_RESULT}', json_encode([]), $response->getContent()));
             return;
         }
 


### PR DESCRIPTION
- Solves issue: #126 
- Description: 
- Tested with Shopware6 editions/versions: 
- Tested with PHP versions: 

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
