### PR TITLE
FFWEB-2659: add missing attribute `category-page`

### DIFF
--- a/src/Subscriber/CategoryPageSubscriber.php
+++ b/src/Subscriber/CategoryPageSubscriber.php
@@ -47,7 +47,8 @@ class CategoryPageSubscriber implements EventSubscriberInterface
 
         $disableImmediate = safeGetByName($category->getCustomFields(), OmikronFactFinder::DISABLE_SEARCH_IMMEDIATE_CUSTOM_FIELD_NAME);
         $isHome           = $route === 'frontend.home.page';
-        $searchImmediate  = $this->config->isSsrActive() === false && !$isHome && !$disableImmediate;
+        $isCategory       = !$isHome && !$disableImmediate;
+        $searchImmediate  = $this->config->isSsrActive() === false && $isCategory;
 
         $baseAddParams = array_filter(explode(',', (string) safeGetByName($event->getPage()->getExtension('factfinder')->get('communication'), 'add-params')));
         /**
@@ -62,7 +63,7 @@ class CategoryPageSubscriber implements EventSubscriberInterface
         $categoryPath  = (new CategoryPath($this->fieldName))->getValue($category);
         $communication = [
                 'add-params'       => implode(',', array_map(fn (string $key, string $value): string => sprintf('%s=%s', $key, $value), array_keys($mergedAddParams), array_values($mergedAddParams))),
-            ] + ($searchImmediate ? ['category-page' => $categoryPath] : []);
+            ] + ($isCategory ? ['category-page' => $categoryPath] : []);
 
         if ($route === 'frontend.navigation.page') {
             $event->getRequest()->attributes->set('categoryPath', $categoryPath);


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2659
- Description:
  - Fix problem with missing attribute `category-page` in `ff-communication` element for Navigation Page
- Tested with Shopware6 editions/versions: 
  - 6.4.18.0
- Tested with PHP versions: 
  - 7.4
  - 8.1