### PR TITLE
FFWEB-2668: Export only active categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Fix
 - SSR
   - fixed problem with not visible search results when SSR enabled
+### Change
+- Export
+  - Export only active categories
 
 ## [v4.1.2] - 2023.02.06
 ### Fix

--- a/src/Export/ExportCategories.php
+++ b/src/Export/ExportCategories.php
@@ -63,6 +63,7 @@ class ExportCategories implements ExportInterface
                 new EqualsFilter(sprintf('customFields.%s', OmikronFactFinder::CMS_EXPORT_INCLUDE_CUSTOM_FIELD_NAME), false),
             ])
         );
+        $criteria->addFilter(new EqualsFilter('active', true));
 
         return $criteria;
     }


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2668
- Description:
  - Export only active categories
- Tested with Shopware6 editions/versions: 
  - 6.4.18.0
- Tested with PHP versions: 
  - 7.4
  - 8.1