### PR TITLE
FFWEB-2667 - Fix sorting for category page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fix
+- Category
+  - Fix sorting - removed redundant parameters `order` and `name`
+
 ## [v4.2.0] - 2023.02.23
 ### Fix
 - SSR

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -34,7 +34,7 @@
 
       document.addEventListener('ffReady', function (e) {
         e.eventAggregator.addBeforeHistoryPushCallback(function (res, event, url) {
-          url = url.replace(/filter=CategoryPath[^&]+&?/, '');
+          url = url.replace(/filter=CategoryPath[^&]+&?/, '').replace(/order=[^&]+&?/, '').replace(/name=[^&]+&?/g, '');
           factfinder.communication.Util.pushParameterToHistory(res, url, event);
           return false;
         });


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2667
- Description:
  - Fix sorting for category page
- Tested with Shopware6 editions/versions: 
  - 6.4.18.0
- Tested with PHP versions: 
  - 7.4
  - 8.1