### PR TITLE
cache field roles as they are searched for on every request

### DIFF
--- a/src/Api/UpdateFieldRolesController.php
+++ b/src/Api/UpdateFieldRolesController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\Api;
 
 use Exception;
-use Omikron\FactFinder\Shopware6\Config\FieldRoles;
+use Omikron\FactFinder\Shopware6\Config\FieldRolesInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
@@ -20,10 +20,10 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 class UpdateFieldRolesController extends AbstractController
 {
-    private FieldRoles $fieldRoles;
+    private FieldRolesInterface $fieldRoles;
     private EntityRepositoryInterface $channelRepository;
 
-    public function __construct(FieldRoles $fieldRolesService, EntityRepositoryInterface $channelRepository)
+    public function __construct(FieldRolesInterface $fieldRolesService, EntityRepositoryInterface $channelRepository)
     {
         $this->fieldRoles        = $fieldRolesService;
         $this->channelRepository = $channelRepository;

--- a/src/Config/CachedFieldRoles.php
+++ b/src/Config/CachedFieldRoles.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Config;
+
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+
+class CachedFieldRoles implements FieldRolesInterface
+{
+    private FieldRolesInterface $decorated;
+    private AdapterInterface $cache;
+
+    public function __construct(FieldRolesInterface $decorated, AdapterInterface $cache)
+    {
+        $this->decorated = $decorated;
+        $this->cache = $cache;
+    }
+
+    public function getRoles(?string $salesChannelId): array
+    {
+        $cacheKey = $this->getCacheKey($salesChannelId);
+        $item = $this->cache->getItem($cacheKey);
+
+        if ($item->isHit()) {
+            return $item->get();
+        }
+
+        $fieldRoles = $this->decorated->getRoles($salesChannelId);
+
+        $item->set($fieldRoles);
+        $this->cache->save($item);
+
+        return $fieldRoles;
+    }
+
+    public function update(array $fieldRoles, ?string $salesChannelId): void
+    {
+        $this->decorated->update($fieldRoles, $salesChannelId);
+
+        $cacheKey = $this->getCacheKey($salesChannelId);
+        if ($this->cache->hasItem($cacheKey)) {
+            $this->cache->deleteItem($cacheKey);
+        }
+    }
+
+    private function getCacheKey(?string $salesChannelId): string
+    {
+        return 'factfinder-field-roles-' . ($salesChannelId ?? '');
+    }
+}

--- a/src/Config/CachedFieldRoles.php
+++ b/src/Config/CachedFieldRoles.php
@@ -14,13 +14,13 @@ class CachedFieldRoles implements FieldRolesInterface
     public function __construct(FieldRolesInterface $decorated, AdapterInterface $cache)
     {
         $this->decorated = $decorated;
-        $this->cache = $cache;
+        $this->cache     = $cache;
     }
 
     public function getRoles(?string $salesChannelId): array
     {
         $cacheKey = $this->getCacheKey($salesChannelId);
-        $item = $this->cache->getItem($cacheKey);
+        $item     = $this->cache->getItem($cacheKey);
 
         if ($item->isHit()) {
             return $item->get();

--- a/src/Config/FieldRoles.php
+++ b/src/Config/FieldRoles.php
@@ -8,7 +8,7 @@ use Omikron\FactFinder\Communication\Resource\Search;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use function Omikron\FactFinder\Shopware6\Internal\Utils\safeGetByName;
 
-class FieldRoles
+class FieldRoles implements FieldRolesInterface
 {
     private Search $search;
     private Communication $communicationConfig;

--- a/src/Config/FieldRolesInterface.php
+++ b/src/Config/FieldRolesInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Omikron\FactFinder\Shopware6\Config;
+
+interface FieldRolesInterface
+{
+    public function getRoles(?string $salesChannelId): array;
+
+    public function update(array $fieldRoles, ?string $salesChannelId): void;
+}

--- a/src/Config/FieldRolesInterface.php
+++ b/src/Config/FieldRolesInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Omikron\FactFinder\Shopware6\Config;
 
 interface FieldRolesInterface

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -75,6 +75,7 @@
             <bind key="$configurationAddParams">%factfinder.configuration.add_params%</bind>
             <bind key="$communicationParameters">%factfinder.communication.parameters.base%</bind>
             <bind key="$entryRepository" type="service" id="factfinder_feed_preprocessor.repository" />
+            <bind key="$cache" type="service" id="cache.object" />
         </defaults>
 
         <service id="Omikron\FactFinder\Shopware6\Communication\AdapterFactory" />
@@ -182,5 +183,7 @@
             <argument type="service" id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Filter"/>
         </service>
         <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Engine" />
+        <service id="Omikron\FactFinder\Shopware6\Config\FieldRolesInterface"
+                 alias="Omikron\FactFinder\Shopware6\Config\FieldRoles" />
     </services>
 </container>

--- a/src/Utilites/Ssr/PriceFormatter.php
+++ b/src/Utilites/Ssr/PriceFormatter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Utilites\Ssr;
 
-use Omikron\FactFinder\Shopware6\Config\FieldRoles;
+use Omikron\FactFinder\Shopware6\Config\CachedFieldRoles;
 use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
 use Shopware\Core\System\Currency\CurrencyFormatter;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -20,7 +20,7 @@ class PriceFormatter
     public function __construct(
         SalesChannelService $channelService,
         CurrencyFormatter $currencyFormatter,
-        FieldRoles $fieldRolesService,
+        CachedFieldRoles $fieldRolesService,
         array $fieldRoles
     ) {
         $this->channelService    = $channelService;

--- a/src/Utilites/Ssr/Template/Filter.php
+++ b/src/Utilites/Ssr/Template/Filter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
 
-use Omikron\FactFinder\Shopware6\Config\FieldRoles;
+use Omikron\FactFinder\Shopware6\Config\CachedFieldRoles;
 use Omikron\FactFinder\Shopware6\Export\Filter\FilterInterface;
 use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
 
@@ -14,7 +14,7 @@ class Filter implements FilterInterface
 
     public function __construct(
         SalesChannelService $channelService,
-        FieldRoles $fieldRolesService
+        CachedFieldRoles $fieldRolesService
     ) {
         $context          = $channelService->getSalesChannelContext();
         $this->fieldRoles = $fieldRolesService->getRoles($context->getSalesChannelId());


### PR DESCRIPTION
Using SSR, every framework startup creates two *-queries against FF backend as the field roles are built in constructor of Utilites/Ssr/Template/Filter.php and Utilites/Ssr/PriceFormatter.php.

We implemented storing the field roles in Shopware's object cache
