### PR TITLE
FFWEB-2691: fix problem with PriceCurrency during export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ### Fix
 - SSR
   - Cache field roles
-- fix problem with new map due to SecurityExtension
+- Fix problem with new map due to SecurityExtension
+- Export
+  - Fix problem with PriceCurrency during export
 
 ## [v4.2.2] - 2023.03.16
 ### Add

--- a/src/Export/Field/PriceCurrency.php
+++ b/src/Export/Field/PriceCurrency.php
@@ -34,4 +34,9 @@ class PriceCurrency extends Price
     {
         return [ProductEntity::class];
     }
+
+    public function __toString(): string
+    {
+        return $this->getName();
+    }
 }

--- a/src/Export/Field/PriceCurrency.php
+++ b/src/Export/Field/PriceCurrency.php
@@ -20,6 +20,11 @@ class PriceCurrency extends Price
         $this->numberFormatter = $numberFormatter;
     }
 
+    public function __toString(): string
+    {
+        return $this->getName();
+    }
+
     public function getName(): string
     {
         return 'Price_' . $this->currency->getIsoCode();
@@ -33,10 +38,5 @@ class PriceCurrency extends Price
     public function getCompatibleEntityTypes(): array
     {
         return [ProductEntity::class];
-    }
-
-    public function __toString(): string
-    {
-        return $this->getName();
     }
 }


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2691
- Description:
  - Fix problem with PriceCurrency during export
- Tested with Shopware6 editions/versions: 
  - 6.4.20.0
- Tested with PHP versions: 
  - 8.2
  - 7.4
