### PR TITLE
error handling

### DIFF
--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -112,7 +112,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         $criteria->addFilter(new EqualsFilter('id', $categoryId));
         $category = $this->categoryRepository->search($criteria, Context::createDefaultContext())->first();
 
-        return $this->categoryPath->getValue($category);
+        return $category !== null ? $this->categoryPath->getValue($category) : '';
     }
 
     private function getCategoryId(Request $request): string


### PR DESCRIPTION
handling for error: Argument #1 ($categoryEntity) must be of type Shopware\Core\Content\Category\CategoryEntity, null given

- Solves issue: 
- Description: 
- Tested with Shopware6 editions/versions: 
- Tested with PHP versions: 

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
