### PR TITLE
pagination for GoogleBot (text version) 

### DIFF
--- a/spec/Storefront/Controller/ResultControllerSpec.php
+++ b/spec/Storefront/Controller/ResultControllerSpec.php
@@ -76,7 +76,8 @@ class ResultControllerSpec extends ObjectBehavior
     public function it_should_return_original_response_content_when_ssr_is_not_active(
         SearchAdapter $searchAdapter,
         Page $page,
-        Engine $mustache
+        Engine $mustache,
+        TemplateFinder $templateFinder
     ) {
         $content = 'original content';
         $this->pageLoader->load($this->request, $this->salesChannelContext)->willReturn($page);
@@ -87,6 +88,8 @@ class ResultControllerSpec extends ObjectBehavior
             $this->request,
             $this->salesChannelContext,
             $searchAdapter,
+            $this->twig,
+            $templateFinder,
             $mustache
         );
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -54,6 +54,7 @@
         </parameter>
         <parameter key="factfinder.data_export.entity_type_map" type="collection">
         </parameter>
+        <parameter key="factfinder.ssr.parameters.page_url_param">page</parameter>
     </parameters>
 
     <services>
@@ -76,6 +77,7 @@
             <bind key="$communicationParameters">%factfinder.communication.parameters.base%</bind>
             <bind key="$entryRepository" type="service" id="factfinder_feed_preprocessor.repository" />
             <bind key="$cache" type="service" id="cache.object" />
+            <bind key="$pageUrlParam">%factfinder.ssr.parameters.page_url_param%</bind>
         </defaults>
 
         <service id="Omikron\FactFinder\Shopware6\Communication\AdapterFactory" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -77,6 +77,7 @@
             <bind key="$communicationParameters">%factfinder.communication.parameters.base%</bind>
             <bind key="$entryRepository" type="service" id="factfinder_feed_preprocessor.repository" />
             <bind key="$cache" type="service" id="cache.object" />
+            <bind key="$templateFinder" type="service" id="Shopware\Core\Framework\Adapter\Twig\TemplateFinder" />
             <bind key="$pageUrlParam">%factfinder.ssr.parameters.page_url_param%</bind>
         </defaults>
 

--- a/src/Resources/views/storefront/components/factfinder/record-list.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/record-list.html.twig
@@ -18,4 +18,7 @@
       {% endif %}
     {% endblock %}
   </ff-record-list>
+  {% if ssr %}
+    <ssr-paging></ssr-paging>
+  {% endif %}
 {% endblock %}

--- a/src/Resources/views/storefront/components/factfinder/ssr-paging.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/ssr-paging.html.twig
@@ -1,0 +1,27 @@
+{% block component_factfinder_ssr_paging %}
+  {% if pageCount > 1 %}
+    <noscript>
+      <nav aria-label="pagination" class="pagination-nav">
+        <ul class="pagination">
+
+          {% set lastpage = 0 %}
+          {% for page, pagelink in pages %}
+            {% if ((page > 1) and (currentPage - page > 2)) or ((page < pageCount) and (page - currentPage > 2)) %}
+              {% continue %}
+            {% endif %}
+            {% if page - lastpage > 1 %}
+              <li class="page-item">
+                <span class="page-link">...</span>
+              </li>
+            {% endif %}
+            <li class="page-item{% if page == currentPage %} active{% endif %}">
+              <a class="page-link" href="{{ pagelink }}">{{ loop.index }}</a>
+            </li>
+            {% set lastpage = page %}
+          {% endfor %}
+
+        </ul>
+      </nav>
+    </noscript>
+  {% endif %}
+{% endblock %}

--- a/src/Resources/views/storefront/components/factfinder/ssr-paging.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/ssr-paging.html.twig
@@ -15,7 +15,11 @@
               </li>
             {% endif %}
             <li class="page-item{% if page == currentPage %} active{% endif %}">
-              <a class="page-link" href="{{ pagelink }}">{{ loop.index }}</a>
+              {% if page == currentPage %}
+                <span class="page-link">{{ page }}</span>
+              {% else %}
+                <a class="page-link" href="{{ pagelink }}">{{ page }}</a>
+              {% endif %}
             </li>
             {% set lastpage = page %}
           {% endfor %}

--- a/src/Storefront/Controller/ResultController.php
+++ b/src/Storefront/Controller/ResultController.php
@@ -45,7 +45,7 @@ class ResultController extends StorefrontController
         Environment $twig,
         TemplateFinderInterface $templateFinder,
         Engine $mustache,
-        string $pageUrlParam
+        string $pageUrlParam = 'page'
     ): Response {
         $page     = $this->pageLoader->load($request, $context);
         $response = $this->renderStorefront('@Parent/storefront/page/factfinder/result.html.twig', ['page' => $page]);

--- a/src/Storefront/Controller/ResultController.php
+++ b/src/Storefront/Controller/ResultController.php
@@ -8,12 +8,14 @@ use Omikron\FactFinder\Shopware6\Config\Communication;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Engine;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\RecordList;
+use Shopware\Core\Framework\Adapter\Twig\TemplateFinderInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Shopware\Storefront\Page\GenericPageLoader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Twig\Environment;
 
 /**
  * @Route(defaults={"_routeScope"={"storefront"}})
@@ -40,7 +42,10 @@ class ResultController extends StorefrontController
         Request $request,
         SalesChannelContext $context,
         SearchAdapter $searchAdapter,
-        Engine $mustache
+        Environment $twig,
+        TemplateFinderInterface $templateFinder,
+        Engine $mustache,
+        string $pageUrlParam
     ): Response {
         $page     = $this->pageLoader->load($request, $context);
         $response = $this->renderStorefront('@Parent/storefront/page/factfinder/result.html.twig', ['page' => $page]);
@@ -51,10 +56,13 @@ class ResultController extends StorefrontController
 
         $recordList = new RecordList(
             $request,
+            $twig,
+            $templateFinder,
             $mustache,
             $searchAdapter,
             $context->getSalesChannelId(),
             $response->getContent(),
+            $pageUrlParam
         );
         $response->setContent(
             $recordList->getContent(

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -25,6 +25,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
     private SearchAdapter $searchAdapter;
     private Engine $mustache;
     private CategoryPath $categoryPath;
+    private string $pageUrlParam;
 
     public function __construct(
         bool $httpCacheEnabled,
@@ -32,7 +33,8 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         Communication $config,
         SearchAdapter $searchAdapter,
         Engine $mustache,
-        CategoryPath $categoryPath
+        CategoryPath $categoryPath,
+        string $pageUrlParam
     ) {
         $this->httpCacheEnabled       = $httpCacheEnabled;
         $this->categoryRepository     = $categoryRepository;
@@ -40,6 +42,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         $this->searchAdapter          = $searchAdapter;
         $this->mustache               = $mustache;
         $this->categoryPath           = $categoryPath;
+        $this->pageUrlParam           = $pageUrlParam;
     }
 
     public static function getSubscribedEvents()
@@ -70,6 +73,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
             $this->searchAdapter,
             $request->attributes->get('sw-sales-channel-id'),
             $response->getContent(),
+            $this->pageUrlParam
         );
         $response->setContent(
             $recordList->getContent(

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -9,6 +9,7 @@ use Omikron\FactFinder\Shopware6\Utilites\Ssr\Field\CategoryPath;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Engine;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\RecordList;
+use Shopware\Core\Framework\Adapter\Twig\TemplateFinderInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -16,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Event\BeforeSendResponseEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Twig\Environment;
 
 class CategoryPageResponseSubscriber implements EventSubscriberInterface
 {
@@ -23,6 +25,8 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
     private EntityRepositoryInterface $categoryRepository;
     private Communication $config;
     private SearchAdapter $searchAdapter;
+    private Environment $twig;
+    private TemplateFinderInterface $templateFinder;
     private Engine $mustache;
     private CategoryPath $categoryPath;
     private string $pageUrlParam;
@@ -32,6 +36,8 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         EntityRepositoryInterface $categoryRepository,
         Communication $config,
         SearchAdapter $searchAdapter,
+        Environment $twig,
+        TemplateFinderInterface $templateFinder,
         Engine $mustache,
         CategoryPath $categoryPath,
         string $pageUrlParam
@@ -40,6 +46,8 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         $this->categoryRepository     = $categoryRepository;
         $this->config                 = $config;
         $this->searchAdapter          = $searchAdapter;
+        $this->twig                   = $twig;
+        $this->templateFinder         = $templateFinder;
         $this->mustache               = $mustache;
         $this->categoryPath           = $categoryPath;
         $this->pageUrlParam           = $pageUrlParam;
@@ -69,6 +77,8 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
 
         $recordList = new RecordList(
             $request,
+            $this->twig,
+            $this->templateFinder,
             $this->mustache,
             $this->searchAdapter,
             $request->attributes->get('sw-sales-channel-id'),

--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -56,7 +56,7 @@ class RecordList
     ) {
         if ($this->pageUrlParam !== 'page') {
             $paramString = strpos($paramString, $this->pageUrlParam . '=') === 0
-                ? sprintf('page=%s', substr($paramString, strlen($this->pageUrlParam)+1))
+                ? sprintf('page=%s', substr($paramString, strlen($this->pageUrlParam) + 1))
                 : str_replace('&' . $this->pageUrlParam . '=', '&page=', $paramString);
         }
 
@@ -104,18 +104,18 @@ class RecordList
     private function setPaging(array $results): void
     {
         $currentPage = (int) ($results['paging']['currentPage'] ?? 1);
-        $pageCount = (int) ($results['paging']['pageCount'] ?? 1);
+        $pageCount   = (int) ($results['paging']['pageCount'] ?? 1);
 
         $twigVars = [
             'currentPage' => $currentPage,
-            'pageCount' => $pageCount,
+            'pageCount'   => $pageCount,
         ];
         for ($page = 1; $page <= $pageCount; $page++) {
             $twigVars['pages'][$page] = $this->paginationUrl($page);
         }
 
         $template = $this->templateFinder->find('@Storefront/storefront/components/factfinder/ssr-paging.html.twig');
-        $paging = $this->twig->render($template, $twigVars);
+        $paging   = $this->twig->render($template, $twigVars);
 
         $this->content = preg_replace(self::SSR_PAGING_PATTERN, $paging, $this->content);
     }

--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
 
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
+use Shopware\Storefront\Framework\Routing\RequestTransformer;
 use Symfony\Component\HttpFoundation\Request;
 
 class RecordList
@@ -18,19 +19,22 @@ class RecordList
     private string $salesChannelId;
     private string $content;
     private string $template;
+    private string $pageUrlParam;
 
     public function __construct(
         Request $request,
         Engine $mustache,
         SearchAdapter $searchAdapter,
         string $salesChannelId,
-        string $content
+        string $content,
+        string $pageUrlParam = 'page'
     ) {
         $this->request        = $request;
         $this->mustache       = $mustache;
         $this->searchAdapter  = $searchAdapter;
         $this->salesChannelId = $salesChannelId;
         $this->content        = $content;
+        $this->pageUrlParam   = $pageUrlParam ?? 'page';
         $this->setTemplateString();
     }
 
@@ -41,9 +45,12 @@ class RecordList
         string $paramString,
         bool $isNavigationRequest = false
     ) {
-        $paramString = strpos($paramString, 'p=') === 0
-            ? sprintf('page=%s', substr($paramString, 2))
-            : str_replace('&p=', '&page=', $paramString);
+        if ($this->pageUrlParam !== 'page') {
+            $paramString = strpos($paramString, $this->pageUrlParam . '=') === 0
+                ? sprintf('page=%s', substr($paramString, strlen($this->pageUrlParam)+1))
+                : str_replace('&' . $this->pageUrlParam . '=', '&page=', $paramString);
+        }
+
         $results        = $this->searchAdapter->search($paramString, $isNavigationRequest, $this->salesChannelId);
         $records        = $results['records'] ?? [];
         $recordsContent = array_reduce(
@@ -57,7 +64,7 @@ class RecordList
         );
 
         $this->content = str_replace('{FF_SEARCH_RESULT}', json_encode($results) ?: '{}', $this->content);
-        $this->setContentWithLinks($results, $paramString);
+        $this->setContentWithLinks($results);
 
         if ($records === []) {
             return $this->content;
@@ -66,22 +73,19 @@ class RecordList
         return preg_replace(self::SSR_RECORD_PATTERN, $recordsContent, $this->content);
     }
 
-    private function setContentWithLinks(array $results, string $paramString): void
+    private function setContentWithLinks(array $results): void
     {
-        $nextPage     = $results['paging']['nextLink']['number'] ?? null;
-        $previousPage = $results['paging']['previousLink']['number'] ?? null;
+        $nextPage     = (int) ($results['paging']['nextLink']['number'] ?? 0);
+        $previousPage = (int) ($results['paging']['previousLink']['number'] ?? 0);
         $nextLink     = '';
         $previousLink = '';
-        $pos          = strpos($this->request->getUri(), '?');
-        $baseUrl      = $pos === false ? $this->request->getUri() : substr($this->request->getUri(), 0, $pos);
-        $params       = array_filter(explode('&', $paramString), fn (string $param) => strpos($param, 'page=') !== 0);
 
-        if ($previousPage !== null) {
-            $previousLink = sprintf('<link rel="prev" href="%s?%s" />', $baseUrl, implode('&', [...$params, sprintf('page=%s', $previousPage)]));
+        if ($previousPage !== 0) {
+            $previousLink = sprintf('<link rel="prev" href="%s" />', $this->paginationUrl($previousPage));
         }
 
-        if ($nextPage !== null) {
-            $nextLink = sprintf('<link rel="next" href="%s?%s" />', $baseUrl, implode('&', [...$params, sprintf('page=%s', $nextPage)]));
+        if ($nextPage !== 0) {
+            $nextLink = sprintf('<link rel="next" href="%s" />', $this->paginationUrl($nextPage));
         }
 
         $this->content = str_replace('</head>', sprintf('%s%s</head>', $previousLink, $nextLink), $this->content);
@@ -92,5 +96,20 @@ class RecordList
         preg_match(self::RECORD_PATTERN, $this->content, $match);
 
         $this->template = $match[0] ?? '';
+    }
+
+    private function paginationUrl(int $page): string
+    {
+        $requestUrl = $this->request->attributes->has(RequestTransformer::ORIGINAL_REQUEST_URI)
+            ? $this->request->getUriForPath($this->request->attributes->get(RequestTransformer::ORIGINAL_REQUEST_URI))
+            : $this->request->getUri();
+        $baseUrl = strtok($requestUrl, '?');
+
+        $params = $this->request->query->all();
+        unset($params[$this->pageUrlParam]);
+
+        $queryString = http_build_query($page === 1 ? $params : array_merge($params, [$this->pageUrlParam => $page]));
+
+        return $baseUrl . ($queryString === '' ? '' : '?' . $queryString);
     }
 }


### PR DESCRIPTION
- Solves issue: part of 118
- Description: add a "static" pagination which can be crawled by GoogleBot (text version) containing real links to the other paginated pages (links that work without any JavaScript)
- Tested with Shopware6 editions/versions: 6.4.12
- Tested with PHP versions: 8.0

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
