### PR TITLE
fix Adding New Column to Feed example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Fix
 - Fix problem with ff-template in search result page
+- Fix some inaccuracies in read.me file
 ## [v4.2.3] - 2023.04.13
 ### Fix
 - SSR

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ The method `getCompatibleEntityTypes` contains an array of Shopware Entity class
 
 ```php
 
+use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 
 class CustomColumn implements FieldInterface
@@ -451,7 +452,7 @@ class CustomColumn implements FieldInterface
     
     public function getCompatibleEntityTypes(): array
     {
-        return [SalesChannelProductEntity::class];
+        return [ProductEntity::class];
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ information which is relevant for your project and not part of a default Shopwar
 how to extend the feed with additional column.
 
 Start with creating field provider - a class
-implementing `Omikron\FactFinder\Shopware6\Export\FieldFieldInterface` which will be used to export your data.
+implementing `Omikron\FactFinder\Shopware6\Export\FieldInterface` which will be used to export your data.
 
 ```php
 


### PR DESCRIPTION
fix Adding New Column to Feed example and use correct ProductEntity class in getCompatibleEntityTypes

- Solves issue: 
Currently the example in the Readme doesn't work and confuses new devs.
- Description: 
fix `Adding New Column to Feed` example 
- Tested with Shopware6 editions/versions: 
only docs changed
- Tested with PHP versions: 
only docs changed

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
