### PR TITLE
FFWEB-2705: Remove deprecations from TextFilter

### DIFF
--- a/src/Export/Filter/TextFilter.php
+++ b/src/Export/Filter/TextFilter.php
@@ -12,8 +12,8 @@ class TextFilter implements FilterInterface
         $tags  = '#<(address|article|aside|blockquote|br|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|li|main|nav|noscript|ol|p|pre|section|table|tfoot|ul|video)#';
         $value = preg_replace($tags, ' <$1', $value); // Add one space in front of block elements before stripping tags
         $value = strip_tags($value);
-        $value = mb_convert_encoding($value, 'HTML-ENTITIES', 'UTF-8');
-        $value = mb_convert_encoding($value, 'UTF-8', 'HTML-ENTITIES');
+        $value = htmlentities($value);
+        $value = html_entity_decode($value);
         $value = preg_replace('#\s+#', ' ', $value);
         return trim($value);
     }


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2702
- Description:
  - mb_convert_encoding is deprecated. Use htmlentities instead.
- Tested with Shopware6 editions/versions: 
  - 6.4.20.0
- Tested with PHP versions: 
  - 8.2
  - 7.4
