### PR TITLE
FFWEB-2707: Fix type for custom_fields and filter_attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Fix
 - Fix problem with ff-template in search result page
 - Fix some inaccuracies in read.me file
+- Remove deprecations for EntityRepository and SalesChannelRepository
+- Fix type for custom_fields and filter_attributes in FeedPreprocessorEntryDefinition
 ## [v4.2.3] - 2023.04.13
 ### Fix
 - SSR

--- a/src/Command/RunPreprocessorCommand.php
+++ b/src/Command/RunPreprocessorCommand.php
@@ -12,7 +12,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -35,16 +35,16 @@ class RunPreprocessorCommand extends Command
     private FeedPreprocessorEntryPersister $entryPersister;
     private ExportProducts $exportProducts;
     private SalesChannelService $channelService;
-    private EntityRepositoryInterface $languageRepository;
-    private EntityRepositoryInterface $channelRepository;
+    private EntityRepository $languageRepository;
+    private EntityRepository $channelRepository;
 
     public function __construct(
         FeedPreprocessor $feedPreprocessor,
         FeedPreprocessorEntryPersister $entryPersister,
         SalesChannelService $salesChannelService,
         ExportProducts $exportProducts,
-        EntityRepositoryInterface $languageRepository,
-        EntityRepositoryInterface $channelRepository
+        EntityRepository $languageRepository,
+        EntityRepository $channelRepository
     ) {
         parent::__construct();
         $this->feedPreprocessor   = $feedPreprocessor;

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -6,7 +6,7 @@ namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
 
 use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
 use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -14,11 +14,11 @@ use Shopware\Core\Framework\Uuid\Uuid;
 class FeedPreprocessorEntryReader
 {
     private SalesChannelService $channelService;
-    private EntityRepositoryInterface $entryRepository;
+    private EntityRepository $entryRepository;
 
     public function __construct(
         SalesChannelService $channelService,
-        EntityRepositoryInterface $entryRepository
+        EntityRepository $entryRepository
     ) {
         $this->channelService  = $channelService;
         $this->entryRepository = $entryRepository;

--- a/src/Export/ExportProducts.php
+++ b/src/Export/ExportProducts.php
@@ -7,17 +7,17 @@ namespace Omikron\FactFinder\Shopware6\Export;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class ExportProducts implements ExportInterface
 {
-    private SalesChannelRepositoryInterface $productRepository;
+    private SalesChannelRepository $productRepository;
 
     /** @var string[] */
     private array $customAssociations;
 
-    public function __construct(SalesChannelRepositoryInterface $productRepository, array $customAssociations)
+    public function __construct(SalesChannelRepository $productRepository, array $customAssociations)
     {
         $this->productRepository  = $productRepository;
         $this->customAssociations = $customAssociations;

--- a/src/Export/FeedPreprocessorEntryDefinition.php
+++ b/src/Export/FeedPreprocessorEntryDefinition.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
@@ -41,8 +42,8 @@ class FeedPreprocessorEntryDefinition extends EntityDefinition
                 (new StringField('product_number', 'productNumber'))->addFlags(new Required()),
                 (new StringField('parent_product_number', 'parentProductNumber')),
                 (new StringField('variation_key', 'variationKey')),
-                (new StringField('filter_attributes', 'filterAttributes'))->addFlags(new Required(), new AllowEmptyString()),
-                (new StringField('custom_fields', 'customFields'))->addFlags(new AllowEmptyString()),
+                (new LongTextField('filter_attributes', 'filterAttributes'))->addFlags(new Required(), new AllowEmptyString()),
+                (new LongTextField('custom_fields', 'customFields'))->addFlags(new AllowEmptyString()),
                 (new JsonField('additional_cache', 'additionalCache')),
             ]
         );


### PR DESCRIPTION
 
- Solves issue:
  - FFWEB-2707
- Description:
  - Fix type for custom_fields and filter_attributes in FeedPreprocessorEntryDefinition
  - Remove deprecations for EntityRepository and SalesChannelRepository
- Tested with Shopware6 editions/versions: 
  - 6.4.20.0
- Tested with PHP versions: 
  - 8.2
  - 7.4
