### PR TITLE
FFWEB-2710: Backward compatibility for Shopware v. 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+### Fix
+- Fix problem with autowire EntityRepository and SalesChannelRepository for Shopware 6.4
 ## [v4.2.4] - 2023.04.26
 ### Fix
 - Fix problem with ff-template in search result page

--- a/src/Command/RunPreprocessorCommand.php
+++ b/src/Command/RunPreprocessorCommand.php
@@ -12,7 +12,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -35,16 +35,16 @@ class RunPreprocessorCommand extends Command
     private FeedPreprocessorEntryPersister $entryPersister;
     private ExportProducts $exportProducts;
     private SalesChannelService $channelService;
-    private EntityRepository $languageRepository;
-    private EntityRepository $channelRepository;
+    private EntityRepositoryInterface $languageRepository;
+    private EntityRepositoryInterface $channelRepository;
 
     public function __construct(
         FeedPreprocessor $feedPreprocessor,
         FeedPreprocessorEntryPersister $entryPersister,
         SalesChannelService $salesChannelService,
         ExportProducts $exportProducts,
-        EntityRepository $languageRepository,
-        EntityRepository $channelRepository
+        EntityRepositoryInterface $languageRepository,
+        EntityRepositoryInterface $channelRepository
     ) {
         parent::__construct();
         $this->feedPreprocessor   = $feedPreprocessor;

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -6,7 +6,7 @@ namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
 
 use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
 use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -14,11 +14,11 @@ use Shopware\Core\Framework\Uuid\Uuid;
 class FeedPreprocessorEntryReader
 {
     private SalesChannelService $channelService;
-    private EntityRepository $entryRepository;
+    private EntityRepositoryInterface $entryRepository;
 
     public function __construct(
         SalesChannelService $channelService,
-        EntityRepository $entryRepository
+        EntityRepositoryInterface $entryRepository
     ) {
         $this->channelService  = $channelService;
         $this->entryRepository = $entryRepository;

--- a/src/Export/ExportProducts.php
+++ b/src/Export/ExportProducts.php
@@ -7,17 +7,17 @@ namespace Omikron\FactFinder\Shopware6\Export;
 use Omikron\FactFinder\Shopware6\Export\Data\Entity\ProductEntity as ExportProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class ExportProducts implements ExportInterface
 {
-    private SalesChannelRepository $productRepository;
+    private SalesChannelRepositoryInterface $productRepository;
 
     /** @var string[] */
     private array $customAssociations;
 
-    public function __construct(SalesChannelRepository $productRepository, array $customAssociations)
+    public function __construct(SalesChannelRepositoryInterface $productRepository, array $customAssociations)
     {
         $this->productRepository  = $productRepository;
         $this->customAssociations = $customAssociations;


### PR DESCRIPTION
- Solves issue:
  - FFWEB-2710
- Description:
  - EntityRepositoryInterface and SalesChannelRepositoryInterface will be deleted in  Shopware v. 6.5 We will prepare special release for compatible with Shopware v. 6.5 soon.
- Tested with Shopware6 editions/versions: 
  - 6.4.20.0
- Tested with PHP versions: 
  - 8.2
  - 7.4
