### PR TITLE
FFWEB-2765: Change type for column variation_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+- Change type to LONGTEXT for column `variation_key` in table `factfinder_feed_preprocessor`
+
 ## [v4.2.6] - 2023.06.22
 ### Change
 - Group 3 FactFinder cookies into one group for Cookie Consent Manager

--- a/src/Export/FeedPreprocessorEntryDefinition.php
+++ b/src/Export/FeedPreprocessorEntryDefinition.php
@@ -41,7 +41,7 @@ class FeedPreprocessorEntryDefinition extends EntityDefinition
                 (new StringField('language_id', 'languageId'))->addFlags(new Required()),
                 (new StringField('product_number', 'productNumber'))->addFlags(new Required()),
                 (new StringField('parent_product_number', 'parentProductNumber')),
-                (new StringField('variation_key', 'variationKey')),
+                (new LongTextField('variation_key', 'variationKey')),
                 (new LongTextField('filter_attributes', 'filterAttributes'))->addFlags(new Required(), new AllowEmptyString()),
                 (new LongTextField('custom_fields', 'customFields'))->addFlags(new AllowEmptyString()),
                 (new JsonField('additional_cache', 'additionalCache')),

--- a/src/Migration/Migration1689762417VariationKeyType.php
+++ b/src/Migration/Migration1689762417VariationKeyType.php
@@ -23,6 +23,9 @@ SQL;
         $connection->executeStatement($query);
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
     public function updateDestructive(Connection $connection): void
     {
     }

--- a/src/Migration/Migration1689762417VariationKeyType.php
+++ b/src/Migration/Migration1689762417VariationKeyType.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1689762417VariationKeyType extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1689762417;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $query = <<<SQL
+ALTER TABLE `factfinder_feed_preprocessor` MODIFY `variation_key` LONGTEXT;
+SQL;
+
+        $connection->executeStatement($query);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // no destructive
+    }
+}

--- a/src/Migration/Migration1689762417VariationKeyType.php
+++ b/src/Migration/Migration1689762417VariationKeyType.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Migration;
 
@@ -23,6 +25,5 @@ SQL;
 
     public function updateDestructive(Connection $connection): void
     {
-        // no destructive
     }
 }


### PR DESCRIPTION
- Solves issue:  FFWEB-2765
- Description: Change type to LONGTEXT for column `variation_key` in table `factfinder_feed_preprocessor`
- Tested with Shopware6 editions/versions: 6.4.20
- Tested with PHP versions: 7.4, 8.2
