### PR TITLE
FFWEB-2779: Replace missing Interfaces in Shopware6.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 /vendor
 .idea
+/vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 ## Unreleased
 ### BREAKING
-- Fix some deprecations for Shopware v6.5
+- IMPORTANT! Drop Shopware 6.4 compatibility
+- IMPORTANT! Drop PHP 7.4 compatibility
+- Upgrade libraries as required Shopware 6.5
+- Fix deprecations for Shopware v6.5
 - Change league/flysystem-sftp to league/flysystem-sftp-v3
-- Upgrade some libraries connected to Shopware 6.5
 
 ## [v4.2.7] - 2023.07.20
 ### Change

--- a/src/Command/DataExportCommand.php
+++ b/src/Command/DataExportCommand.php
@@ -21,7 +21,7 @@ use Omikron\FactFinder\Shopware6\Upload\UploadService;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -58,11 +58,11 @@ class DataExportCommand extends Command implements ContainerAwareInterface
     private const BRANDS_EXPORT_TYPE     = 'brands';
 
     private SalesChannelService $channelService;
-    private EntityRepositoryInterface $channelRepository;
+    private EntityRepository $channelRepository;
     private FeedFactory $feedFactory;
     private UploadService $uploadService;
     private PushImportService $pushImportService;
-    private EntityRepositoryInterface $languageRepository;
+    private EntityRepository $languageRepository;
     private CurrencyFieldsProvider $currencyFieldsProvider;
     private FieldsProvider $fieldProviders;
 
@@ -71,11 +71,11 @@ class DataExportCommand extends Command implements ContainerAwareInterface
 
     public function __construct(
         SalesChannelService $channelService,
-        EntityRepositoryInterface $channelRepository,
+        EntityRepository $channelRepository,
         FeedFactory $feedFactory,
         UploadService $uploadService,
         PushImportService $pushImportService,
-        EntityRepositoryInterface $languageRepository,
+        EntityRepository $languageRepository,
         CurrencyFieldsProvider $currencyFieldsProvider,
         FieldsProvider $fieldProviders,
         ContainerInterface $container

--- a/src/Command/RunPreprocessorCommand.php
+++ b/src/Command/RunPreprocessorCommand.php
@@ -12,7 +12,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -35,16 +35,16 @@ class RunPreprocessorCommand extends Command
     private FeedPreprocessorEntryPersister $entryPersister;
     private ExportProducts $exportProducts;
     private SalesChannelService $channelService;
-    private EntityRepositoryInterface $languageRepository;
-    private EntityRepositoryInterface $channelRepository;
+    private EntityRepository $languageRepository;
+    private EntityRepository $channelRepository;
 
     public function __construct(
         FeedPreprocessor $feedPreprocessor,
         FeedPreprocessorEntryPersister $entryPersister,
         SalesChannelService $salesChannelService,
         ExportProducts $exportProducts,
-        EntityRepositoryInterface $languageRepository,
-        EntityRepositoryInterface $channelRepository
+        EntityRepository $languageRepository,
+        EntityRepository $channelRepository
     ) {
         parent::__construct();
         $this->feedPreprocessor   = $feedPreprocessor;

--- a/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
+++ b/src/DataAbstractionLayer/FeedPreprocessorEntryReader.php
@@ -6,7 +6,7 @@ namespace Omikron\FactFinder\Shopware6\DataAbstractionLayer;
 
 use Omikron\FactFinder\Shopware6\Export\FeedPreprocessorEntry;
 use Omikron\FactFinder\Shopware6\Export\SalesChannelService;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -14,11 +14,11 @@ use Shopware\Core\Framework\Uuid\Uuid;
 class FeedPreprocessorEntryReader
 {
     private SalesChannelService $channelService;
-    private EntityRepositoryInterface $entryRepository;
+    private EntityRepository $entryRepository;
 
     public function __construct(
         SalesChannelService $channelService,
-        EntityRepositoryInterface $entryRepository
+        EntityRepository $entryRepository
     ) {
         $this->channelService  = $channelService;
         $this->entryRepository = $entryRepository;

--- a/src/Export/ExportCategories.php
+++ b/src/Export/ExportCategories.php
@@ -9,17 +9,17 @@ use Omikron\FactFinder\Shopware6\OmikronFactFinder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
-use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class ExportCategories implements ExportInterface
 {
-    private SalesChannelRepositoryInterface $categoryRepository;
+    private SalesChannelRepository $categoryRepository;
 
     /** @var string[] */
     private array $customAssociations;
 
-    public function __construct(SalesChannelRepositoryInterface $categoryRepository, array $customAssociations)
+    public function __construct(SalesChannelRepository $categoryRepository, array $customAssociations)
     {
         $this->categoryRepository = $categoryRepository;
         $this->customAssociations = $customAssociations;

--- a/src/Export/ExportCmsPages.php
+++ b/src/Export/ExportCmsPages.php
@@ -8,17 +8,17 @@ use Omikron\FactFinder\Shopware6\Export\Data\Entity\CmsPageEntity;
 use Omikron\FactFinder\Shopware6\OmikronFactFinder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class ExportCmsPages implements ExportInterface
 {
-    private SalesChannelRepositoryInterface $categoryRepository;
+    private SalesChannelRepository $categoryRepository;
 
     /** @var string[] */
     private array $customAssociations;
 
-    public function __construct(SalesChannelRepositoryInterface $categoryRepository, array $customAssociations)
+    public function __construct(SalesChannelRepository $categoryRepository, array $customAssociations)
     {
         $this->categoryRepository = $categoryRepository;
         $this->customAssociations = $customAssociations;

--- a/src/MessageQueue/FeedExportHandler.php
+++ b/src/MessageQueue/FeedExportHandler.php
@@ -6,13 +6,13 @@ namespace Omikron\FactFinder\Shopware6\MessageQueue;
 
 use Omikron\FactFinder\Shopware6\Command\DataExportCommand;
 use Omikron\FactFinder\Shopware6\Message\FeedExport;
-use Shopware\Core\Framework\MessageQueue\Handler\AbstractMessageHandler;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
 
-class FeedExportHandler extends AbstractMessageHandler
+class FeedExportHandler implements MessageSubscriberInterface
 {
     private Application $application;
 
@@ -27,7 +27,7 @@ class FeedExportHandler extends AbstractMessageHandler
      *
      * @throws \Exception
      */
-    public function handle($message): void
+    public function __invoke(FeedExport $message): void
     {
         $input = new ArrayInput([
             'command'                                               => 'factfinder:data:export',

--- a/src/MessageQueue/RefreshExportCacheHandler.php
+++ b/src/MessageQueue/RefreshExportCacheHandler.php
@@ -6,13 +6,13 @@ namespace Omikron\FactFinder\Shopware6\MessageQueue;
 
 use Omikron\FactFinder\Shopware6\Command\RunPreprocessorCommand;
 use Omikron\FactFinder\Shopware6\Message\RefreshExportCache;
-use Shopware\Core\Framework\MessageQueue\Handler\AbstractMessageHandler;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
 
-class RefreshExportCacheHandler extends AbstractMessageHandler
+class RefreshExportCacheHandler implements MessageSubscriberInterface
 {
     private Application $application;
 
@@ -27,7 +27,7 @@ class RefreshExportCacheHandler extends AbstractMessageHandler
      *
      * @throws \Exception
      */
-    public function handle($message): void
+    public function __invoke(RefreshExportCache $message): void
     {
         $input = new ArrayInput([
             'command'                                                    => 'factfinder:data:pre-process',

--- a/src/OmikronFactFinder.php
+++ b/src/OmikronFactFinder.php
@@ -9,7 +9,7 @@ use Omikron\FactFinder\Shopware6\Export\Data\Factory\FactoryInterface;
 use Omikron\FactFinder\Shopware6\Export\ExportInterface;
 use Omikron\FactFinder\Shopware6\Export\Field\FieldInterface;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Plugin;
@@ -138,14 +138,14 @@ class OmikronFactFinder extends Plugin
 
     private function installCustomFieldsSet(array $data, Context $context): void
     {
-        /** @var EntityRepositoryInterface $customFielSetRepository */
+        /** @var EntityRepository $customFielSetRepository */
         $customFieldSetRepository = $this->container->get('custom_field_set.repository');
         $customFieldSetRepository->create([$data], $context);
     }
 
     private function installCustomField(array $data, Context $context, string $setName): void
     {
-        /** @var EntityRepositoryInterface $customFieldRepository */
+        /** @var EntityRepository $customFieldRepository */
         $customFieldsRepository = $this->container->get('custom_field.repository');
         $customFieldSet         = $this->getCustomFieldSet($setName, $context);
         if (!$customFieldSet) {
@@ -161,7 +161,7 @@ class OmikronFactFinder extends Plugin
      */
     private function fixCMSExportIncludeFieldType(Context $context): void
     {
-        /** @var EntityRepositoryInterface $customFieldRepository */
+        /** @var EntityRepository $customFieldRepository */
         $customFieldRepository = $this->container->get('custom_field.repository');
 
         $field = $this->getCustomField(OmikronFactFinder::CMS_EXPORT_INCLUDE_CUSTOM_FIELD_NAME, $context);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -173,6 +173,10 @@
             <argument type="service" id="Omikron\FactFinder\Shopware6\Export\Data\Factory\PreprocessedProductEntityFactory.inner"/>
         </service>
 
+        <service id="Symfony\Component\DependencyInjection\ContainerInterface">
+            <argument type="service" id="service_container"/>
+        </service>
+
         <service id="Omikron\FactFinder\Shopware6\Subscriber\FeedPreprocessorEntrySubscriber">
             <argument type="service" id="product.repository"/>
         </service>

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -10,7 +10,7 @@ use Omikron\FactFinder\Shopware6\Utilites\Ssr\SearchAdapter;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Engine;
 use Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\RecordList;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Event\BeforeSendResponseEvent;
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 class CategoryPageResponseSubscriber implements EventSubscriberInterface
 {
     private bool $httpCacheEnabled;
-    private EntityRepositoryInterface $categoryRepository;
+    private EntityRepository $categoryRepository;
     private Communication $config;
     private SearchAdapter $searchAdapter;
     private Engine $mustache;
@@ -28,7 +28,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
 
     public function __construct(
         bool $httpCacheEnabled,
-        EntityRepositoryInterface $categoryRepository,
+        EntityRepository $categoryRepository,
         Communication $config,
         SearchAdapter $searchAdapter,
         Engine $mustache,

--- a/src/Subscriber/FeedPreprocessorEntrySubscriber.php
+++ b/src/Subscriber/FeedPreprocessorEntrySubscriber.php
@@ -6,7 +6,7 @@ namespace Omikron\FactFinder\Shopware6\Subscriber;
 
 use Omikron\FactFinder\Shopware6\Events\FeedPreprocessorEntryBeforeCreate;
 use Omikron\FactFinder\Shopware6\Export\Field\CategoryPath;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -14,10 +14,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class FeedPreprocessorEntrySubscriber implements EventSubscriberInterface
 {
     private CategoryPath $categoryFieldGenerator;
-    private EntityRepositoryInterface $productRepository;
+    private EntityRepository $productRepository;
 
     public function __construct(
-        EntityRepositoryInterface $productRepository,
+        EntityRepository $productRepository,
         CategoryPath $categoryPath
     ) {
         $this->productRepository      = $productRepository;

--- a/src/Subscriber/ProductIndexerSubscriber.php
+++ b/src/Subscriber/ProductIndexerSubscriber.php
@@ -12,7 +12,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NandFilter;
@@ -25,15 +25,15 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ProductIndexerSubscriber implements EventSubscriberInterface
 {
-    private EntityRepositoryInterface $productRepository;
-    private EntityRepositoryInterface $languageRepository;
+    private EntityRepository $productRepository;
+    private EntityRepository $languageRepository;
     private FeedPreprocessor $feedPreprocessor;
     private FeedPreprocessorEntryPersister $entryPersister;
     private ExportSettings $exportSettings;
 
     public function __construct(
-        EntityRepositoryInterface $productRepository,
-        EntityRepositoryInterface $languageRepository,
+        EntityRepository $productRepository,
+        EntityRepository $languageRepository,
         FeedPreprocessor $feedPreprocessor,
         FeedPreprocessorEntryPersister $entryPersister,
         ExportSettings $exportSettings


### PR DESCRIPTION
- Solves issue: FFWEB-2779
- Description:  Replace missing Interfaces EntityRepositoryInterface SalesChannelRepositoryInterface and  in Shopware6.5.
- Tested with Shopware6 editions/versions: 6.5
- Tested with PHP versions: 8.1
