### PR TITLE
FFWEB-2781: Migrate Bootstrap framework from v4 to v5

### DIFF
--- a/src/Resources/app/storefront/src/scss/_asn.scss
+++ b/src/Resources/app/storefront/src/scss/_asn.scss
@@ -7,12 +7,12 @@ ff-asn {
     max-width: none;
 
     &[opened] .filter-panel-item-toggle {
-      border-color: $custom-select-focus-border-color;
+      border-color: $form-select-focus-border-color;
       outline: 0;
       @if $enable-shadows {
-        box-shadow: $custom-select-box-shadow, $custom-select-focus-box-shadow;
+        box-shadow: $form-select-box-shadow, $form-select-focus-box-shadow;
       } @else {
-        box-shadow: $custom-select-focus-box-shadow;
+        box-shadow: $form-select-focus-box-shadow;
       }
     }
 

--- a/src/Resources/app/storefront/src/scss/_searchbox.scss
+++ b/src/Resources/app/storefront/src/scss/_searchbox.scss
@@ -5,7 +5,7 @@ ff-searchbox {
   }
 
   .header-search-input {
-    @include border-right-radius(0);
+    @include border-end-radius(0);
   }
 
   &:focus-within ~ .input-group-append .header-search-btn {
@@ -19,6 +19,6 @@ ff-searchbutton {
   }
 
   .header-search-btn {
-    @include border-left-radius(0);
+    @include border-start-radius(0);
   }
 }

--- a/src/Subscriber/BeforeSendResponseEventSubscriber.php
+++ b/src/Subscriber/BeforeSendResponseEventSubscriber.php
@@ -17,7 +17,7 @@ class BeforeSendResponseEventSubscriber implements EventSubscriberInterface
     public const HAS_JUST_LOGGED_OUT = 'ff_has_just_logged_out';
     public const USER_ID             = 'ff_user_id';
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             BeforeSendResponseEvent::class => [


### PR DESCRIPTION
- Solves issue: FFWEB-2781
- Description: Migrate Bootstrap framework from v4 to v5
- Tested with Shopware6 editions/versions: 6.5
- Tested with PHP versions: 8.1
