### PR TITLE
SSR: error handling for empty category paths

### DIFF
--- a/src/Utilites/Ssr/Field/CategoryPath.php
+++ b/src/Utilites/Ssr/Field/CategoryPath.php
@@ -20,7 +20,7 @@ class CategoryPath
         $categories   = array_slice($categoryEntity->getBreadcrumb(), 1);
         $categoryPath = implode('/', array_map(fn ($category): string => $this->encodeCategoryName($category), $categories));
 
-        return sprintf('filter=%s', urlencode($this->fieldName . ':' . $categoryPath));
+        return $categoryPath !== '' ? sprintf('filter=%s', urlencode($this->fieldName . ':' . $categoryPath)) : '';
     }
 
     private function encodeCategoryName(string $path): string


### PR DESCRIPTION
error handling for `400 Bad Request` response: {"error":"Bad Request","errorDescription":"The filter parameter value after the : must not be empty"} on categories with empty breadcrumb

