### PR TITLE
error handling for usage of TextFilter with null value

### DIFF
--- a/src/Export/Filter/ExtendedTextFilter.php
+++ b/src/Export/Filter/ExtendedTextFilter.php
@@ -8,8 +8,9 @@ class ExtendedTextFilter extends TextFilter
 {
     private const FORBIDDEN_CHARS = '/[|#=]/';
 
-    public function filterValue(string $value): string
+    public function filterValue(?string $value): string
     {
+        $value = $value ?? '';
         return trim(preg_replace(self::FORBIDDEN_CHARS, ' ', parent::filterValue($value)));
     }
 }

--- a/src/Export/Filter/FilterInterface.php
+++ b/src/Export/Filter/FilterInterface.php
@@ -9,5 +9,5 @@ namespace Omikron\FactFinder\Shopware6\Export\Filter;
  */
 interface FilterInterface
 {
-    public function filterValue(string $value): string;
+    public function filterValue(?string $value): string;
 }

--- a/src/Export/Filter/TextFilter.php
+++ b/src/Export/Filter/TextFilter.php
@@ -6,10 +6,11 @@ namespace Omikron\FactFinder\Shopware6\Export\Filter;
 
 class TextFilter implements FilterInterface
 {
-    public function filterValue(string $value): string
+    public function filterValue(?string $value): string
     {
         // phpcs:ignore
         $tags  = '#<(address|article|aside|blockquote|br|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|li|main|nav|noscript|ol|p|pre|section|table|tfoot|ul|video)#';
+        $value = $value ?? '';
         $value = preg_replace($tags, ' <$1', $value); // Add one space in front of block elements before stripping tags
         $value = strip_tags($value);
         $value = htmlentities($value);

--- a/src/Utilites/Ssr/Template/Filter.php
+++ b/src/Utilites/Ssr/Template/Filter.php
@@ -20,8 +20,9 @@ class Filter implements FilterInterface
         $this->fieldRoles = $fieldRolesService->getRoles($context->getSalesChannelId());
     }
 
-    public function filterValue(string $value): string
+    public function filterValue(?string $value): string
     {
+        $value = $value ?? '';
         $value = preg_replace('#data-anchor="([^"]+?)"#', 'href="$1" $0', $value);
         $value = preg_replace('#data-redirect-target="_(blank|self|parent|top)"#', 'target="_$1" $0', $value);
         return preg_replace_callback('#data-image(?:="([^"]+?)")?#', function (array $match): string {


### PR DESCRIPTION
error handling for error `Omikron\FactFinder\Shopware6\Export\Filter\TextFilter::filterValue(): Argument #1 ($value) must be of type string, null given`
