### PR TITLE
FFWEB-2803: Error handling for empty category paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## Unreleased
+### Fix
+- Error handling for empty category paths
+### Change
+- Separate searching and rendering process for Record List
+
 ## [v4.2.8] - 2023.08.22
 ### Fix
 - Fix save cookies into Shopware Cookie Consent Manager

--- a/src/Utilites/Ssr/Field/CategoryPath.php
+++ b/src/Utilites/Ssr/Field/CategoryPath.php
@@ -20,7 +20,7 @@ class CategoryPath
         $categories   = array_slice($categoryEntity->getBreadcrumb(), 1);
         $categoryPath = implode('/', array_map(fn ($category): string => $this->encodeCategoryName($category), $categories));
 
-        return sprintf('filter=%s', urlencode($this->fieldName . ':' . $categoryPath));
+        return $categoryPath !== '' ? sprintf('filter=%s', urlencode($this->fieldName . ':' . $categoryPath)) : '';
     }
 
     private function encodeCategoryName(string $path): string


### PR DESCRIPTION
- Solves issue: FFWEB-2803
- Description:  Error handling for empty category paths
- Tested with Shopware6 editions/versions: 6.4
- Tested with PHP versions: 7.4

