### PR TITLE
FFWEB-2832: Add test API connection button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+### Add
+- Add test API connection button
 ### Fix
 - Error handling for empty category paths
 ### Change

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ store cache in order the new applied configuration to start working.
 * API Version - Used FACT-Finder® api version   
   **Note:** Module supports FACT-Finder® api version `v4` and `v5`. By selecting the wrong api version you may cause the Web Components to be unable to communicate with FACT-Finder®
 
+You can check if the above data is correctly set by clicking on the `Test Connection` button. Please save your settings before clicking on button.
+
 #### Update Field Roles
 This functionality offers a way to download field roles configured in FACT-Finder®.
 Please use this if you don't use feed offered by the plugin or for some reason you have changed the column names.

--- a/src/Api/TestConnectionController.php
+++ b/src/Api/TestConnectionController.php
@@ -23,7 +23,7 @@ class TestConnectionController extends AbstractController
     public function __construct(ClientBuilder $clientBuilder, CommunicationConfig $config)
     {
         $this->clientBuilder = $clientBuilder;
-        $this->config = $config;
+        $this->config        = $config;
     }
 
     /**

--- a/src/Api/TestConnectionController.php
+++ b/src/Api/TestConnectionController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Shopware6\Api;
+
+use Omikron\FactFinder\Communication\Client\ClientBuilder;
+use Omikron\FactFinder\Communication\Credentials;
+use Omikron\FactFinder\Shopware6\Config\Communication as CommunicationConfig;
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @RouteScope(scopes={"api"})
+ */
+class TestConnectionController extends AbstractController
+{
+    private ClientBuilder $clientBuilder;
+    private CommunicationConfig $config;
+
+    public function __construct(ClientBuilder $clientBuilder, CommunicationConfig $config)
+    {
+        $this->clientBuilder = $clientBuilder;
+        $this->config = $config;
+    }
+
+    /**
+     * @Route("/api/_action/test-connection/api", name="api.action.fact_finder.test_api_connection", methods={"GET"}, defaults={"XmlHttpRequest"=true})
+     */
+    public function testApiConnection(): JsonResponse
+    {
+        $client = $this->clientBuilder
+            ->withCredentials(new Credentials(...$this->config->getCredentials()))
+            ->withServerUrl($this->config->getServerUrl())
+            ->withVersion($this->config->getVersion())
+            ->build();
+
+        try {
+            $endpoint = $this->createTestEndpoint();
+            $client->request('GET', $endpoint);
+
+            return new JsonResponse(['message' => 'Connection successfully established'], 200);
+        } catch (\Exception $e) {
+            return new JsonResponse(['message' => 'Connection could not be established'], 400);
+        }
+    }
+
+    private function createTestEndpoint(): string
+    {
+        $apiVersion = $this->config->getApiVersion();
+        $channel    = $this->config->getChannel();
+
+        return "rest/{$apiVersion}/records/{$channel}/compare";
+    }
+}

--- a/src/Resources/app/administration/src/module/configuration/component/test-api-connection/index.js
+++ b/src/Resources/app/administration/src/module/configuration/component/test-api-connection/index.js
@@ -1,0 +1,58 @@
+import template from './test-api-connection.html.twig';
+import './test-api-connection.scss';
+
+const {Component, Mixin} = Shopware;
+
+Component.register('test-api-connection', {
+        template,
+        mixins: [
+            Mixin.getByName('notification'),
+            Mixin.getByName('sw-inline-snippet'),
+        ],
+        data() {
+            return {
+                isLoading: false,
+                isSaveSuccessful: false,
+            };
+        },
+
+        methods: {
+            async onClick() {
+                this.isLoading = true;
+                const httpClient = Shopware.Service('syncService').httpClient;
+                const url = '_action/test-connection/api';
+                const basicHeaders = {
+                    Authorization: `Bearer ${Shopware.Context.api.authToken.access}`,
+                    'Content-Type': 'application/json'
+                };
+
+                httpClient
+                    .get(url, {
+                        headers: basicHeaders
+                    })
+                    .then((response) => {
+                        if (response.status === 200) {
+                            this.createNotificationSuccess({
+                                message: this.$tc('configuration.testConnection.success')
+                            });
+                        } else {
+                            this.createNotificationError({
+                                title: this.$tc('configuration.testConnection.fail'),
+                                message: this.$tc('configuration.testConnection.helpText')
+                            });
+                        }
+                    })
+                    .catch(() => {
+                        this.createNotificationError({
+                            title: this.$tc('configuration.testConnection.fail'),
+                            message: this.$tc('configuration.testConnection.helpText')
+                        });
+                    })
+                    .finally(() => {
+                        this.isSaveSuccessful = true;
+                        this.isLoading = false;
+                    });
+            },
+        },
+    },
+);

--- a/src/Resources/app/administration/src/module/configuration/component/test-api-connection/test-api-connection.html.twig
+++ b/src/Resources/app/administration/src/module/configuration/component/test-api-connection/test-api-connection.html.twig
@@ -1,0 +1,9 @@
+<sw-button-process
+  class="test-connection-btn"
+  variant="primary"
+  :isLoading="isLoading"
+  :disabled="isLoading"
+  :processSuccess="isSaveSuccessful"
+  @click="onClick">
+  {{ $tc('configuration.testApiConnection.testConnection') }}
+</sw-button-process>

--- a/src/Resources/app/administration/src/module/configuration/component/test-api-connection/test-api-connection.scss
+++ b/src/Resources/app/administration/src/module/configuration/component/test-api-connection/test-api-connection.scss
@@ -1,0 +1,4 @@
+.test-connection-btn {
+  margin-top: 10px;
+  width: 176px;
+}

--- a/src/Resources/app/administration/src/module/configuration/index.js
+++ b/src/Resources/app/administration/src/module/configuration/index.js
@@ -1,1 +1,2 @@
 import './component/update-field-roles';
+import './component/test-api-connection';

--- a/src/Resources/app/administration/src/module/configuration/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/configuration/snippet/de-DE.json
@@ -2,6 +2,14 @@
   "configuration": {
     "updateFieldRoles": {
       "update": "Update Field Roles"
+    },
+    "testConnection": {
+      "success": "Connection successfully established.",
+      "fail": "Connection could not be established.",
+      "helpText": "Please save you current configuration before test connection"
+    },
+    "testApiConnection": {
+      "testConnection": "Test Connection"
     }
   }
 }

--- a/src/Resources/app/administration/src/module/configuration/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/configuration/snippet/en-GB.json
@@ -3,6 +3,14 @@
     "updateFieldRoles": {
       "update": "Update Field Roles",
       "successMessage": "Updated Field Roles successfully. Please check if values are correct"
+    },
+    "testConnection": {
+      "success": "Connection successfully established.",
+      "fail": "Connection could not be established.",
+      "helpText": "Please save you current configuration before test connection"
+    },
+    "testApiConnection": {
+      "testConnection": "Test Connection"
     }
   }
 }

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -60,6 +60,10 @@
         <component name="update-field-roles">
             <name>fieldRoles</name>
         </component>
+
+        <component name="test-api-connection">
+            <name>testApiConnection</name>
+        </component>
     </card>
 
     <card>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -136,6 +136,7 @@
         </service>
         <service id="Omikron\FactFinder\Shopware6\Api\UiFeedExportController" />
         <service id="Omikron\FactFinder\Shopware6\Api\UpdateFieldRolesController" />
+        <service id="Omikron\FactFinder\Shopware6\Api\TestConnectionController" />
 
         <service id="Omikron\FactFinder\Shopware6\MessageQueue\FeedExportHandler">
             <tag name="messenger.message_handler" />


### PR DESCRIPTION
- Solves issue: FFWEB-2832
- Description: Add test API connection button
- Tested with Shopware6 editions/versions: 6.4
- Tested with PHP versions: 7.4
