### PR TITLE
FFWEB-2930: Filter empty attributes for ff-communication component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Filter empty attributes for ff-communication component
+
 ## [v4.3.1] - 2023.10.26
 ### Change
 - Shopware Cookie Consent Manager improvement

--- a/src/Subscriber/ConfigurationSubscriber.php
+++ b/src/Subscriber/ConfigurationSubscriber.php
@@ -57,9 +57,12 @@ class ConfigurationSubscriber implements EventSubscriberInterface
             'channel'               => $this->config->getChannel($salesChannelId),
             'version'               => $this->config->getVersion(),
             'api'                   => $this->config->getApiVersion(),
-            'currency-code'         => $event->getSalesChannelContext()->getCurrency()->getIsoCode(),
-            'currency-country-code' => $event->getRequest()->getLocale(),
+            'currency-code'         => $event->getSalesChannelContext()->getCurrency()->getIsoCode() ?? '',
+            'currency-country-code' => $event->getRequest()->getLocale() ?? '',
         ];
+
+        //Filter empty items
+        $communication = array_filter($communication);
 
         if (!empty($this->addParams)) {
             $communication['add-params'] = implode(',', $this->addParams);


### PR DESCRIPTION
- Solves issue:  FFWEB-2930
- Description:  Filter empty attributes for ff-communication component
- Tested with Shopware6 editions/versions: 6.4
- Tested with PHP versions: 7.4 
