### PR TITLE
FFWEB-2955: Set FactFinder cookies as required in CookieConsentManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 ### Fix
 - Filter empty attributes for ff-communication component
+### Change
+- Set FactFinder cookies as required for Cookie Consent Manager
 
 ## [v4.3.1] - 2023.10.26
 ### Change

--- a/src/Cookie/CookieProvider.php
+++ b/src/Cookie/CookieProvider.php
@@ -10,7 +10,7 @@ use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 class CookieProvider implements CookieProviderInterface
 {
     private const FF_COOKIE_GROUP = [
-        'isRequired' => true,
+        'isRequired'           => true,
         'snippet_name'         => 'ff.cookie.groupName',
         'snippet_description'  => 'ff.cookie.groupDescription',
         'entries'              => [

--- a/src/Cookie/CookieProvider.php
+++ b/src/Cookie/CookieProvider.php
@@ -10,20 +10,24 @@ use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 class CookieProvider implements CookieProviderInterface
 {
     private const FF_COOKIE_GROUP = [
+        'isRequired' => true,
         'snippet_name'         => 'ff.cookie.groupName',
         'snippet_description'  => 'ff.cookie.groupDescription',
         'entries'              => [
             [
                 'snippet_name' => 'ff.cookie.hasJustLogIn',
                 'cookie'       => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_IN,
+                'value'        => '0',
             ],
             [
                 'snippet_name' => 'ff.cookie.hasJustLogOut',
                 'cookie'       => BeforeSendResponseEventSubscriber::HAS_JUST_LOGGED_OUT,
+                'value'        => '0',
             ],
             [
                 'snippet_name' => 'ff.cookie.userId',
                 'cookie'       => BeforeSendResponseEventSubscriber::USER_ID,
+                'value'        => '0',
             ],
         ],
     ];

--- a/src/Resources/snippet/factfinder.de-DE.json
+++ b/src/Resources/snippet/factfinder.de-DE.json
@@ -18,7 +18,7 @@
     },
     "cookie": {
       "groupName": "FactFinder",
-      "groupDescription": "Cookie, das für das ordnungsgemäße Funktionieren des Benutzer-Login-Tracking-Ereignisses erforderlich ist",
+      "groupDescription": "Cookie erforderlich, damit das FactFinder-Plugin ordnungsgemäß funktioniert",
       "hasJustLogIn": "FactFinder Nutzer hat sich gerade angemeldet",
       "hasJustLogOut": "FactFinder Nutzer hat sich gerade abgemeldet",
       "userId": "FactFinder Nutzer ID"

--- a/src/Resources/snippet/factfinder.en-GB.json
+++ b/src/Resources/snippet/factfinder.en-GB.json
@@ -18,7 +18,7 @@
     },
     "cookie": {
       "groupName": "FactFinder",
-      "groupDescription": "Cookie required for proper working of user login tracking event",
+      "groupDescription": "Cookie required for proper working of FactFinder plugin",
       "hasJustLogIn": "FactFinder user log in information",
       "hasJustLogOut": "FactFinder user log out information",
       "userId": "FactFinder user id information"


### PR DESCRIPTION
- Solves issue:  FFWEB-2955
- Description:Set FactFinder cookies as required in CookieConsentManager
- Tested with Shopware6 editions/versions: 6.4.20
- Tested with PHP versions: 7.4
