### PR TITLE
FFWEB-2965: Add PHPStan for checking code quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+- Add PHPStan
+
 ## [v5.0.0] - 2023.10.24
 ### BREAKING
 - IMPORTANT! Drop Shopware 6.4 compatibility

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "friendsofphp/php-cs-fixer": "^3.22",
     "phpmd/phpmd": "^2.9",
     "phpspec/phpspec": "^7.2",
-    "phpunit/phpunit": "^9.5"
+    "phpunit/phpunit": "^9.5",
+    "phpstan/phpstan": "^1.10"
   },
   "autoload": {
     "psr-4": {
@@ -33,6 +34,7 @@
   },
   "scripts": {
     "test": [
+      "vendor/bin/phpstan analyse -c phpstan.neon",
       "php-cs-fixer fix --dry-run -v",
       "phpspec run --format=dot",
       "phpmd src text phpmd.xml.dist",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,26 @@
+parameters:
+    level: 0
+
+    bootstrapFiles:
+        - %currentWorkingDirectory%/vendor/autoload.php
+    paths:
+        - %currentWorkingDirectory%
+    excludePaths:
+        - %currentWorkingDirectory%/Components/Smarty
+        - %currentWorkingDirectory%/vendor
+        - %currentWorkingDirectory%/tests/
+        - %currentWorkingDirectory%/Test/
+        - %currentWorkingDirectory%/Resources/smarty
+        - %currentWorkingDirectory%/platform
+        - %currentWorkingDirectory%/autoload-dist/vendor/
+
+    ignoreErrors:
+        - '#apcu_#'
+        - '#ioncube_#'
+        - '#opcache_#'
+        - '#imagettftext#'
+        - '#class Redis#'
+        - '#Constant STARTTIME#'
+
+    reportUnmatchedIgnoredErrors: false
+    tipsOfTheDay: false

--- a/src/DataAbstractionLayer/FeedPreprocessor.php
+++ b/src/DataAbstractionLayer/FeedPreprocessor.php
@@ -54,7 +54,7 @@ class FeedPreprocessor
 
         $visibleGroupIds = $this->extractVisibleGroupIds($product);
 
-        /** @var \Shopware\Core\Content\Product\ProductEntity $child */
+        /** @var ProductEntity $child */
         foreach ($product->getChildren() as $child) {
             // fetch storefront presentation config for each variant
             $shouldGroupBeVisible = fn (string $groupId): bool => in_array($groupId, $visibleGroupIds);

--- a/src/OmikronFactFinder.php
+++ b/src/OmikronFactFinder.php
@@ -50,7 +50,7 @@ class OmikronFactFinder extends Plugin
             'config' => [
                 'label'               => [
                     'en-GB' => 'Disable `ff-communication/search-immediate`',
-                    'en-GB' => 'Disable `ff-communication/search-immediate`',
+                    'de-DE' => 'Disable `ff-communication/search-immediate`',
                 ],
                 'componentName'       => 'sw-field',
                 'customFieldType'     => CustomFieldTypes::SWITCH,

--- a/src/Subscriber/ConfigurationSubscriber.php
+++ b/src/Subscriber/ConfigurationSubscriber.php
@@ -19,6 +19,7 @@ class ConfigurationSubscriber implements EventSubscriberInterface
 {
     private Communication $config;
     private ExtensionConfig $extensionConfig;
+    private RouterInterface $router;
     private array $fieldRoles;
     private array $communicationParameters;
     private array $addParams;


### PR DESCRIPTION
- Solves issue: FFWEB-2965
- Description: Add PHPStan for checking code quality
- Tested with Shopware6 editions/versions: 6.5
- Tested with PHP versions: 8.1

