### PR TITLE
FFWEB-2984: Add validation for plugin config

### DIFF
--- a/src/Communication/ClientBuilderConfigurator.php
+++ b/src/Communication/ClientBuilderConfigurator.php
@@ -7,22 +7,29 @@ namespace Omikron\FactFinder\Shopware6\Communication;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Credentials;
 use Omikron\FactFinder\Shopware6\Config\Communication as CommunicationConfig;
+use Psr\Log\LoggerInterface;
 
 class ClientBuilderConfigurator
 {
     private CommunicationConfig $config;
+    private LoggerInterface $factfinderLogger;
 
-    public function __construct(CommunicationConfig $config)
+    public function __construct(CommunicationConfig $config, LoggerInterface $factfinderLogger)
     {
-        $this->config = $config;
+        $this->config           = $config;
+        $this->factfinderLogger = $factfinderLogger;
     }
 
     public function configure(ClientBuilder $clientBuilder): void
     {
         $clientBuilder->withCredentials(new Credentials(...$this->config->getCredentials()));
 
-        if ($this->config->getServerUrl() !== '') {
-            $clientBuilder->withServerUrl($this->config->getServerUrl());
+        try {
+            if ($this->config->getServerUrl() !== '') {
+                $clientBuilder->withServerUrl($this->config->getServerUrl());
+            }
+        } catch (\InvalidArgumentException $e) {
+            $this->factfinderLogger->error($e->getMessage());
         }
     }
 }

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -6,7 +6,7 @@
         <title>Main Settings</title>
         <title lang="de-DE">Grundeinstellungen</title>
 
-        <input-field>
+        <input-field type="url">
             <name>serverUrl</name>
             <label>Server URL</label>
             <label lang="de-DE">Server-URL</label>
@@ -108,7 +108,6 @@
             <placeholder>phrase one=/some/special/link/one
 phrase two=https://domain.com/some/special/link/two
             </placeholder>
-            <required>false</required>
         </input-field>
     </card>
 
@@ -165,12 +164,11 @@ phrase two=https://domain.com/some/special/link/two
             <required>true</required>
         </input-field>
 
-        <input-field>
+        <input-field type="int">
             <name>ftpPort</name>
             <label>Port</label>
             <defaultValue>21</defaultValue>
             <label lang="de-DE">Port</label>
-            <required>false</required>
         </input-field>
 
         <input-field>
@@ -184,7 +182,6 @@ phrase two=https://domain.com/some/special/link/two
             <name>ftpPassword</name>
             <label>Password</label>
             <label lang="de-DE">Passwort</label>
-            <required>false</required>
             <helpText>If your authentication method does not require user password, please ignore that file</helpText>
             <helpText lang="de-DE">Wenn Ihre Authentifizierungsmethode kein Benutzerkennwort erfordert, ignorieren Sie diese Datei bitte</helpText>
         </input-field>
@@ -193,7 +190,6 @@ phrase two=https://domain.com/some/special/link/two
             <name>rootDir</name>
             <label>Root Directory</label>
             <label lang="de-DE"></label>
-            <required>false</required>
         </input-field>
 
         <input-field type="textarea">


### PR DESCRIPTION
- Solves issue: FFWEB-2984
- Description: Add validation for plugin config
- Tested with Shopware6 editions/versions: 6.5
- Tested with PHP versions: 8.2
