### PR TITLE
FFWEB-2985: Plugin uninstallation process

### DIFF
--- a/src/FactFinder.php
+++ b/src/FactFinder.php
@@ -120,11 +120,11 @@ class FactFinder extends Plugin
 
     public function uninstall(UninstallContext $uninstallContext): void
     {
+        parent::uninstall($uninstallContext);
+
         if (!$uninstallContext->keepUserData()) {
             $this->removeModuleData($uninstallContext);
         }
-
-        parent::uninstall($uninstallContext);
     }
 
     public function executeComposerCommands(): bool


### PR DESCRIPTION
Plugin uninstallation process

- Solves issue: FFWEB-2985
- Description: Plugin uninstallation process
- Tested with Shopware6 editions/versions: 6.5
- Tested with PHP versions: 8.2

