### PR TITLE
FFWEB-2987: Ged rid of <hx> tags from templates

### DIFF
--- a/src/Resources/app/administration/src/module/sw-cms/elements/asn/config/sw-cms-el-config-asn.html.twig
+++ b/src/Resources/app/administration/src/module/sw-cms/elements/asn/config/sw-cms-el-config-asn.html.twig
@@ -38,7 +38,7 @@
     </sw-textarea-field>
 
     <wrapper class="secondary">
-      <h3 class="filter-cloud">Filter Cloud</h3>
+      <div class="h3 filter-cloud">Filter Cloud</div>
       <sw-switch-field label="Use Filter Cloud" v-model="element.config.filterCloud.value"></sw-switch-field>
 
       <sw-container v-if="element.config.filterCloud.value">

--- a/src/Resources/views/storefront/components/factfinder/asn.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/asn.html.twig
@@ -1,6 +1,6 @@
 {% block component_filter_panel_header %}
   <div class="filter-panel-offcanvas-header">
-    <h3 class="filter-panel-offcanvas-only">{{ 'listing.filterTitleText'|trans }}</h3>
+    <div class="h3 filter-panel-offcanvas-only">{{ 'listing.filterTitleText'|trans }}</div>
     <div class="filter-panel-offcanvas-only filter-panel-offcanvas-close js-offcanvas-close">
       {% sw_icon 'x' style { size: 'md' } %}
     </div>

--- a/src/Resources/views/storefront/components/factfinder/campaign-advisor.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/campaign-advisor.html.twig
@@ -3,7 +3,7 @@
     {% block component_factfinder_campaign_advisor_question %}
       <ff-campaign-advisor-question>
         <span>
-            <h1 data-question>{{ '{{{text}}}' }}</h1>
+          <div class="h1" data-question>{{ '{{{text}}}' }}</div>
         </span>
         <div>
           {% block component_factfinder_campaign_advisor_question_answer %}

--- a/src/Resources/views/storefront/layout/factfinder/suggest.html.twig
+++ b/src/Resources/views/storefront/layout/factfinder/suggest.html.twig
@@ -4,21 +4,21 @@
       {% block layout_search_suggest_result_suggest_container %}
         <section class="ff-suggest-container row pb-4">
           <div data-container="searchTerm" class="col">
-            <h3 class="h5 container-caption">{{ 'ff.suggest.SearchTerms'|trans|striptags }}</h3>
+            <div class="h5 container-caption">{{ 'ff.suggest.SearchTerms'|trans|striptags }}</div>
             <ff-suggest-item type="searchTerm">
               <span class="ff-search-term">{{ '{{{name}}}' }}</span>
             </ff-suggest-item>
           </div>
 
           <div data-container="category" class="col">
-            <h3 class="h5 container-caption">{{ 'ff.suggest.Categories'|trans|striptags }}</h3>
+            <div class="h5 container-caption">{{ 'ff.suggest.Categories'|trans|striptags }}</div>
             <ff-suggest-item type="category">
               <span class="ff-category">{{ '{{{name}}}' }}</span>
             </ff-suggest-item>
           </div>
 
           <div data-container="brand" class="col">
-            <h3 class="h5 container-caption">{{ 'ff.suggest.Brands'|trans|striptags }}</h3>
+            <div class="h5 container-caption">{{ 'ff.suggest.Brands'|trans|striptags }}</div>
             <ff-suggest-item type="brand">
               <span class="ff-brand">{{ '{{{name}}}' }}</span>
             </ff-suggest-item>
@@ -28,7 +28,7 @@
 
       {% block layout_search_suggest_result_product_container %}
         <section class="ff-suggest-container ff-suggest-container--products">
-          <h3 class="h5 container-caption">{{ 'ff.suggest.Products'|trans|striptags }}</h3>
+          <div class="h5 container-caption">{{ 'ff.suggest.Products'|trans|striptags }}</div>
           {% block layout_search_suggest_result_product %}
             <div data-container="productName">
               <ff-suggest-item type="productName">

--- a/src/Resources/views/storefront/page/factfinder/result.html.twig
+++ b/src/Resources/views/storefront/page/factfinder/result.html.twig
@@ -7,7 +7,7 @@
     {% sw_include '@Parent/storefront/components/factfinder/campaign-advisor.html.twig' %}
     {% sw_include '@Parent/storefront/components/factfinder/campaign-pushed-products.html.twig' %}
     {% block page_search_headline %}
-      <h1 class="search-headline">
+      <div class="h1 search-headline">
         {% block page_search_headline_text %}
           <ff-template scope="result" unresolved>
             {{ 'ff.search.headlineBefore'|trans|sw_sanitize }}
@@ -17,7 +17,7 @@
             {{ 'ff.search.headlineAfter'|trans|sw_sanitize }}
           </ff-template>
         {% endblock %}
-      </h1>
+      </div>
     {% endblock %}
     <div class="cms-block-container">
       <div class="cms-block-container-row row cms-row">


### PR DESCRIPTION
- Solves issue: FFWEB-2987
- Description: <hx> tags are forbidden in marketplace version. Change it to `<div class="h1">`
- Tested with Shopware6 editions/versions: 6.5
- Tested with PHP versions: 8.1
