### PR TITLE
SSR: move handling for Redirect Campaigns

### DIFF
--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -46,16 +46,13 @@ class RecordList
     ): string {
         $results = $this->searchResults($paramString, $isNavigationRequest);
 
-        // Support redirect campaigns for SSR
-        if ($this->getRedirectCampaign($results)) {
-            throw new DetectRedirectCampaignException($this->getRedirectCampaign($results));
-        }
-
         return $this->renderResults($results, $paramString);
     }
 
     /**
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @throws DetectRedirectCampaignException
      */
     public function searchResults(
         string $paramString,
@@ -65,7 +62,14 @@ class RecordList
             ? sprintf('page=%s', substr($paramString, 2))
             : str_replace('&p=', '&page=', $paramString);
 
-        return $this->searchAdapter->search($paramString, $isNavigationRequest, $this->salesChannelId);
+        $results = $this->searchAdapter->search($paramString, $isNavigationRequest, $this->salesChannelId);
+
+        // Support redirect campaigns for SSR
+        if ($this->getRedirectCampaign($results)) {
+            throw new DetectRedirectCampaignException($this->getRedirectCampaign($results));
+        }
+
+        return $results;
     }
 
     public function renderResults(


### PR DESCRIPTION
... in searching so it also works if we use searching and rendering separated in our customization


In this PR
https://github.com/FACT-Finder-Web-Components/shopware6-plugin/pull/169
we separated searching and rendering in 2 methods.

We use these 2 methods in our customizations (instead of just "getContent")


This PR
https://github.com/FACT-Finder-Web-Components/shopware6-plugin/pull/187
this separation is ignored.
I moved this functionality into one of the separated methods, so it works for "getContent" as well as "searchResults"+"renderResults".


- Solves issue: 
- Description: 
- Tested with Shopware6 editions/versions: 
- Tested with PHP versions: 

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
