### PR TITLE
FFWEB-3126: Handle js error if wishlist plugin is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Handle js error if wishlist plugin is active
+
 ## [v2.1.0] - 2024.07.10
 ### Fix
 - Handle category-page for ff-communication

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "omikron/shopware6-factfinder",
   "description": "FACT-Finder® Web Components for Shopware 6",
   "type": "shopware-platform-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "proprietary",
   "authors": [
     {

--- a/src/Resources/views/storefront/block/cms-block-listing.html.twig
+++ b/src/Resources/views/storefront/block/cms-block-listing.html.twig
@@ -27,7 +27,7 @@
   </div>
 
   <div class="col-12">
-    <div class="cms-element-product-listing-wrapper pt-3">
+    <div class="ff-cms-element-product-listing-wrapper pt-3">
       <div class="cms-element-product-listing">
         <div class="cms-element-product-listing-actions row justify-content-between">
           <div class="col-md-auto pt-3" data-cms-element-id="{{ element.id }}">

--- a/src/Resources/views/storefront/page/factfinder/result.html.twig
+++ b/src/Resources/views/storefront/page/factfinder/result.html.twig
@@ -47,7 +47,7 @@
       </div>
     </div>
 
-    <div class="cms-element-product-listing-wrapper">
+    <div class="ff-cms-element-product-listing-wrapper">
       <div class="cms-element-product-listing">
         {% sw_include '@Parent/storefront/components/factfinder/toolbar.html.twig' %}
         {% sw_include '@Parent/storefront/components/factfinder/record-list.html.twig' with { subscribe: true, class: 'row cms-listing-row', ssr: page.extensions.factfinder.ssr } %}


### PR DESCRIPTION
- Solves issue: FFWEB-3126
- Description: Handle js error if wishlist plugin is active
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.3

