### PR TITLE
Use all Slot Config for CMS Feed

### DIFF
--- a/src/Export/Field/Layout.php
+++ b/src/Export/Field/Layout.php
@@ -43,7 +43,14 @@ class Layout implements FieldInterface
         }
 
         $layout = array_map(
-            fn (CmsSlotEntity $slot) => safeGetByName(safeGetByName($slot->getConfig(), 'content'), 'value'),
+            function (CmsSlotEntity $slot) {
+
+                if (!$config = $slot->getConfig()) {
+                    return '';
+                }
+
+                return implode('', array_column($config, 'value'));
+            },
             flatMap(
                 fn (CmsBlockEntity $block): array => $this->toValues($block->getSlots()),
                 flatMap(


### PR DESCRIPTION
- Solves issue: 
Only element configs which are named "content" were used for cms export. 

- Description: 
On huge shops where multiple custom CSM Element are builded or inserted via external plugins, the cms feed only uses configs that are named "content". Since every dev is free in naming and one element could have multiple fields beside content, like e.g. "headline" or "description", those fields were ignored and can not be used in factfinder.

This PR simply uses all configs of a slot.
It is not perfectly done because it would kind of crash when the value is an array.

So please consider this PR as a friendly hint or feature request.

- Tested with Shopware6 editions/versions: 
6.5.8.12
- Tested with PHP versions: 
8.2.20
