### PR TITLE
FFWEB-3133: Remove uasort() deprecation for CMS export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+### Fix
+- Remove uasort() deprecation for CMS export
 ## [v5.2.0] - 2024.07.12
 ### Add
 - Add userId for cart tracking

--- a/src/Command/DataExportCommand.php
+++ b/src/Command/DataExportCommand.php
@@ -197,6 +197,7 @@ class DataExportCommand extends Command implements ContainerAwareInterface
     {
         $base   = (array) $this->container->getParameter(sprintf('factfinder.export.%s.columns.base', $exportType));
         $fields = $this->fieldProviders->getFields($entityClass);
+
         return array_values(
             array_unique(
                 array_merge(

--- a/src/Export/Field/Layout.php
+++ b/src/Export/Field/Layout.php
@@ -66,13 +66,21 @@ class Layout implements FieldInterface
         if (!$collection) {
             return [];
         }
+
         /**
          * @param CmsBlockEntity|CmsSectionEntity $current
          * @param CmsBlockEntity|CmsSectionEntity $next
          *
-         * @return bool
+         * @return int
          */
-        $sortByPosition = fn ($current, $next): bool => !method_exists($current, 'getPosition') || $current->getPosition() > $next->getPosition();
+        $sortByPosition = function ($current, $next) {
+            if (!method_exists($current, 'getPosition')) {
+                return 0;
+            }
+
+            return ($current->getPosition() > $next->getPosition()) ? 1 : -1;
+        };
+
         $collection->sort($sortByPosition);
 
         return array_values($collection->getElements());


### PR DESCRIPTION
- Solves issue: FFWEB-3133
- Description:  Remove uasort() deprecation for CMS export
- Tested with Shopware6 editions/versions: 6.5
- Tested with PHP versions: 8.3

