### PR TITLE
FFWEB-3138: Fix SSR problem for category pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## Unreleased
 ### Fix
 - Remove uasort() deprecation for CMS export
+- Fix SSR problem for category pages
+- Fix Shopware download export issue
+
 ## [v5.2.0] - 2024.07.12
 ### Add
 - Add userId for cart tracking

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -14,10 +14,11 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\Event\BeforeSendResponseEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -50,18 +51,21 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            BeforeSendResponseEvent::class => 'onPageRendered',
+            KernelEvents::RESPONSE => 'onPageRendered',
         ];
     }
 
-    public function onPageRendered(BeforeSendResponseEvent $event): void
+    public function onPageRendered(ResponseEvent $event): void
     {
         $request      = $event->getRequest();
         $response     = $event->getResponse();
         $categoryPath = $this->getCategoryPath($request);
 
-        if (
-            $this->config->isSsrActive() === false
+        if ($response->getContent() === false) {
+            return;
+        }
+
+        if ($this->config->isSsrActive() === false
             || $request->isXmlHttpRequest()
             || $categoryPath === ''
         ) {


### PR DESCRIPTION
- Solves issue: FFWEB-3138
- Description: Fix SSR problem for category pages.  Fix Shopware download export issue
- Tested with Shopware6 editions/versions: 6.5
- Tested with PHP versions: 8.2