### PR TITLE
FFWEB-3142: Fix uasort() deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 ## Unreleased
+### BREAKING
 - IMPORTANT! Drop Shopware 6.5 compatibility
 - IMPORTANT! Drop PHP 8.1 compatibility
 - Add support for Shopware 6.6
 - Upgrade libraries as required Shopware v6.6
 - Upgrade symfony to version 7
 - Refactor vue component to vue version 3
+
+### Fix
+- Remove uasort() deprecation for CMS export
+- Fix SSR problem for category pages
+- Fix Shopware download export issue
+- Fix problem with filter btn for not FF category page
 
 ## [v5.2.0] - 2024.07.12
 ### Add

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
     }
   ],
   "require": {
+    "ext-json": "*",
     "omikron/factfinder-communication-sdk": "^0.9.9",
     "shopware/core": "~6.6.0",
     "shopware/storefront": "~6.6.0",
     "php": "~8.2.0||~8.3.0",
-    "ext-json": "*",
     "mustache/mustache": "^2.14",
     "league/flysystem-sftp-v3": "^3.0",
     "league/flysystem-ftp": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,18 @@
     }
   ],
   "require": {
-    "omikron/factfinder-communication-sdk": "^0.9.7",
-    "shopware/core": "~6.5.0",
-    "shopware/storefront": "~6.5.0",
-    "league/flysystem-sftp-v3": "3.15.0",
-    "php": "~8.1.0||~8.2.0||~8.3.0",
+    "omikron/factfinder-communication-sdk": "^0.9.9",
+    "shopware/core": "~6.6.0",
+    "shopware/storefront": "~6.6.0",
+    "php": "~8.2.0||~8.3.0",
     "ext-json": "*",
     "mustache/mustache": "^2.14",
+    "league/flysystem-sftp-v3": "^3.0",
     "league/flysystem-ftp": "^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.22",
+    "squizlabs/php_codesniffer": "^3.0",
     "phpmd/phpmd": "^2.9",
     "phpspec/phpspec": "^7.2",
     "phpunit/phpunit": "^9.5",
@@ -34,7 +35,7 @@
   },
   "scripts": {
     "test": [
-      "vendor/bin/phpstan analyse -c phpstan.neon",
+      "vendor/bin/phpstan analyse -c phpstan.neon --memory-limit 4048M",
       "php-cs-fixer fix --dry-run -v",
       "phpspec run --format=dot",
       "phpmd src text phpmd.xml.dist",

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,17 @@
     }
   ],
   "require": {
+    "omikron/factfinder-communication-sdk": "^0.9.7",
+    "shopware/core": "~6.5.0",
+    "shopware/storefront": "~6.5.0",
+    "league/flysystem-sftp-v3": "3.15.0",
+    "php": "~8.1.0||~8.2.0||~8.3.0",
     "ext-json": "*",
-    "omikron/factfinder-communication-sdk": "^0.9.9",
-    "shopware/core": "~6.6.0",
-    "shopware/storefront": "~6.6.0",
-    "php": "~8.2.0||~8.3.0",
     "mustache/mustache": "^2.14",
-    "league/flysystem-sftp-v3": "^3.0",
     "league/flysystem-ftp": "^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.22",
-    "squizlabs/php_codesniffer": "^3.0",
     "phpmd/phpmd": "^2.9",
     "phpspec/phpspec": "^7.2",
     "phpunit/phpunit": "^9.5",
@@ -35,6 +34,7 @@
   },
   "scripts": {
     "test": [
+      "vendor/bin/phpstan analyse -c phpstan.neon",
       "php-cs-fixer fix --dry-run -v",
       "phpspec run --format=dot",
       "phpmd src text phpmd.xml.dist",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
   },
   "scripts": {
     "test": [
-      "vendor/bin/phpstan analyse -c phpstan.neon",
       "php-cs-fixer fix --dry-run -v",
       "phpspec run --format=dot",
       "phpmd src text phpmd.xml.dist",

--- a/spec/Storefront/Controller/ResultControllerSpec.php
+++ b/spec/Storefront/Controller/ResultControllerSpec.php
@@ -11,6 +11,7 @@ use PhpSpec\ObjectBehavior;
 use PhpSpec\Wrapper\Collaborator;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
+use Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Event\NestedEventDispatcher;
@@ -35,6 +36,7 @@ class ResultControllerSpec extends ObjectBehavior
     private Collaborator $salesChannelContext;
     private Collaborator $twig;
     private Collaborator $seoUrlPlaceholderHandler;
+    private Collaborator $mediaUrlPlaceholderHandler;
 
     public function let(
         Request $request,
@@ -48,15 +50,17 @@ class ResultControllerSpec extends ObjectBehavior
         NestedEventDispatcher $nestedEventDispatcher,
         SystemConfigService $systemConfigService,
         Environment $twig,
-        SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler
+        SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler,
+        MediaUrlPlaceholderHandlerInterface $mediaUrlPlaceholderHandler
     ): void {
-        $this->request                  = $request;
-        $this->config                   = $config;
-        $this->pageLoader               = $pageLoader;
-        $this->container                = $container;
-        $this->salesChannelContext      = $salesChannelContext;
-        $this->twig                     = $twig;
-        $this->seoUrlPlaceholderHandler = $seoUrlPlaceholderHandler;
+        $this->request                    = $request;
+        $this->config                     = $config;
+        $this->pageLoader                 = $pageLoader;
+        $this->container                  = $container;
+        $this->salesChannelContext        = $salesChannelContext;
+        $this->twig                       = $twig;
+        $this->seoUrlPlaceholderHandler   = $seoUrlPlaceholderHandler;
+        $this->mediaUrlPlaceholderHandler = $mediaUrlPlaceholderHandler;
         $this->beConstructedWith($config, $pageLoader);
         $requestStack->getCurrentRequest()->willReturn($request);
         $container->get('request_stack')->willReturn($requestStack);
@@ -68,6 +72,7 @@ class ResultControllerSpec extends ObjectBehavior
         $this->container->get('event_dispatcher')->willReturn($nestedEventDispatcher);
         $this->container->get(SystemConfigService::class)->willReturn($systemConfigService);
         $this->container->get(SeoUrlPlaceholderHandlerInterface::class)->willReturn($seoUrlPlaceholderHandler);
+        $this->container->get(MediaUrlPlaceholderHandlerInterface::class)->willReturn($mediaUrlPlaceholderHandler);
         $this->setTwig($twig);
         $nestedEventDispatcher->dispatch(Argument::any())->willReturn(Argument::any());
         $this->setContainer($container);
@@ -83,6 +88,7 @@ class ResultControllerSpec extends ObjectBehavior
         $this->config->isSsrActive()->willReturn(false);
         $this->twig->render('@OmikronFactFinder/storefront/page/factfinder/result.html.twig', Argument::any())->willReturn($content);
         $this->seoUrlPlaceholderHandler->replace($content, 'https://shop.com', $this->salesChannelContext)->willReturn($content);
+        $this->mediaUrlPlaceholderHandler->replace($content)->willReturn($content);
         $response = $this->result(
             $this->request,
             $this->salesChannelContext,

--- a/src/Export/Field/Layout.php
+++ b/src/Export/Field/Layout.php
@@ -70,9 +70,15 @@ class Layout implements FieldInterface
          * @param CmsBlockEntity|CmsSectionEntity $current
          * @param CmsBlockEntity|CmsSectionEntity $next
          *
-         * @return bool
+         * @return int
          */
-        $sortByPosition = fn ($current, $next): bool => !method_exists($current, 'getPosition') || $current->getPosition() > $next->getPosition();
+        $sortByPosition = function ($current, $next) {
+            if (!method_exists($current, 'getPosition')) {
+                return 0;
+            }
+
+            return ($current->getPosition() > $next->getPosition()) ? 1 : -1;
+        };
         $collection->sort($sortByPosition);
 
         return array_values($collection->getElements());

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -61,6 +61,10 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         $response     = $event->getResponse();
         $categoryPath = $this->getCategoryPath($request);
 
+        if ($response->getContent() === false) {
+            return;
+        }
+
         if ($this->config->isSsrActive() === false
             || $request->isXmlHttpRequest()
             || $categoryPath === ''


### PR DESCRIPTION
- Solves issue: FFWEB-3142
- Description: 
   - Remove uasort() deprecation for CMS export
   - Fix Shopware download export issue
   - Update changelog
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2
