### PR TITLE
FFWEB-3145: Handle js error if wishlist plugin is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix SSR problem for category pages
 - Fix Shopware download export issue
 - Fix problem with filter btn for not FF category page
+- Handle js error if wishlist plugin is active
 
 ## [v5.2.0] - 2024.07.12
 ### Add

--- a/src/Resources/views/storefront/block/cms-block-listing.html.twig
+++ b/src/Resources/views/storefront/block/cms-block-listing.html.twig
@@ -27,7 +27,7 @@
   </div>
 
   <div class="col-12">
-    <div class="cms-element-product-listing-wrapper pt-3">
+    <div class="ff-cms-element-product-listing-wrapper pt-3">
       <div class="cms-element-product-listing">
         <div class="cms-element-product-listing-actions row justify-content-between">
           <div class="col-md-auto pt-3" data-cms-element-id="{{ element.id }}">

--- a/src/Resources/views/storefront/page/factfinder/result.html.twig
+++ b/src/Resources/views/storefront/page/factfinder/result.html.twig
@@ -47,7 +47,7 @@
       </div>
     </div>
 
-    <div class="cms-element-product-listing-wrapper">
+    <div class="ff-cms-element-product-listing-wrapper">
       <div class="cms-element-product-listing">
         {% sw_include '@Parent/storefront/components/factfinder/toolbar.html.twig' %}
         {% sw_include '@Parent/storefront/components/factfinder/record-list.html.twig' with { subscribe: true, class: 'row cms-listing-row', ssr: page.extensions.factfinder.ssr } %}


### PR DESCRIPTION
- Solves issue: FFWEB-3145
- Description: Handle js error if wishlist plugin is active
- Tested with Shopware6 editions/versions: 6.5
- Tested with PHP versions: 8.1

