### PR TITLE
FFWEB-3148: Display recommendation and similar product on PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fix
 - Fix problem with filter btn for not FF category page
 - Fix shopping experience FF vue components
+- Display by default recommendation and similar product on PDP
 
 ## [v2.1.1] - 2024.08.07
 ### Fix

--- a/src/Resources/views/storefront/element/cms-element-product-description-reviews.html.twig
+++ b/src/Resources/views/storefront/element/cms-element-product-description-reviews.html.twig
@@ -1,7 +1,7 @@
-{% sw_extends '@Parent/storefront/page/product-detail/tabs.html.twig' %}
+{% sw_extends '@Parent/storefront/element/cms-element-product-description-reviews.html.twig' %}
 {% set product_number = page.product.productNumber %}
 
-{% block page_product_detail_tabs_inner %}
+{% block element_product_description_reviews %}
   {% set recordListSliderOptions  = {
     productboxMinWidth: '300px',
     slider: {


### PR DESCRIPTION
- Solves issue: FFWEB-3148
- Description: Display recommendation and similar product on PDP
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.3

