### PR TITLE
Filters the products for the data feed to contain only active children

### DIFF
--- a/src/Export/ExportProducts.php
+++ b/src/Export/ExportProducts.php
@@ -56,6 +56,10 @@ class ExportProducts implements ExportInterface
             $criteria->addAssociation($association);
         }
         $criteria->addFilter(new EqualsFilter('parentId', null));
+
+        $criteria->getAssociation('children')
+            ->addFilter(new EqualsFilter('active', true));
+
         return $criteria;
     }
 }


### PR DESCRIPTION
- Solves issue: Filters product to contain only active children
- Description: 
- Tested with Shopware6 editions/versions: 6.5.6.1
- Tested with PHP versions: 8.2

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**

I'm not quite sure, if all 3 conditions should be checked here for the children like Shopware does for products in the ProductAvailableFilter:

self::CONNECTION_AND,
            [
                new RangeFilter('product.visibilities.visibility', [RangeFilter::GTE => $visibility]),
                new EqualsFilter('product.visibilities.salesChannelId', $salesChannelId),
                new EqualsFilter('product.active', true),
            ]