### PR TITLE
Adds association to load children properties and includes them in the FilterAttributes

### DIFF
--- a/src/Export/ExportProducts.php
+++ b/src/Export/ExportProducts.php
@@ -46,6 +46,7 @@ class ExportProducts implements ExportInterface
         $criteria->addAssociation('categories');
         $criteria->addAssociation('categoriesRo');
         $criteria->addAssociation('children.options.group');
+        $criteria->addAssociation('children.properties.group');
         $criteria->addAssociation('manufacturer');
         $criteria->addAssociation('properties');
         $criteria->addAssociation('customFields');

--- a/src/Export/Field/FilterAttributes.php
+++ b/src/Export/Field/FilterAttributes.php
@@ -34,10 +34,15 @@ class FilterAttributes implements FieldInterface
      */
     public function getValue(Entity $entity): string
     {
-        $attributes = $entity->getChildren()->reduce(
-            fn (array $result, Product $child): array => $result + array_map($this->propertyFormatter, $child->getOptions()->getElements()),
-            array_map($this->propertyFormatter, $this->applyPropertyGroupsFilter($entity))
-        );
+        $attributes = array_map($this->propertyFormatter, $this->applyPropertyGroupsFilter($entity));
+
+        if ($entity->getChildren()) {
+            $attributes = $entity->getChildren()->reduce(
+                fn(array $result, Product $child): array => $result + array_map($this->propertyFormatter, $child->getOptions()->getElements()),
+                $attributes
+            );
+        }
+
         return $attributes ? '|' . implode('|', array_values($attributes)) . '|' : '';
     }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -134,6 +134,7 @@
             <tag name="factfinder.export.variant_field"/>
         </service>
         <service id="Omikron\FactFinder\Shopware6\Export\Field\FilterAttributes">
+            <tag name="factfinder.export.variant_field"/>
             <tag name="factfinder.export.cached_product_entity"/>
         </service>
         <service id="Omikron\FactFinder\Shopware6\Api\UiFeedExportController" />


### PR DESCRIPTION

- Solves issue: Missing children properties in data feed
- Description: 
- Tested with Shopware6 editions/versions: 6.5.6.1
- Tested with PHP versions: 8.2

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
