### PR TITLE
FFWEB-3224: Example how to export variants names

### DIFF
--- a/src/Export/Data/Entity/ProductEntity.php
+++ b/src/Export/Data/Entity/ProductEntity.php
@@ -57,6 +57,11 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
         return $this->product->getProductNumber();
     }
 
+    public function getProductName(): string
+    {
+        return (string) $this->product->getTranslation('name');
+    }
+
     public function getFilterAttributes(): string
     {
         return $this->filterAttributes;
@@ -100,7 +105,7 @@ class ProductEntity implements ExportEntityInterface, ProductEntityInterface
         $defaultFields           = [
             'ProductNumber'    => $this->product->getProductNumber(),
             'Master'           => $isVariant ? $this->parent->getProductNumber() : $this->product->getProductNumber(),
-            'Name'             => (string) $this->product->getTranslation('name'),
+            'Name'             => $this->getProductName(),
             'FilterAttributes' => $this->getFilterAttributes(),
             'CustomFields'     => $this->getCustomFields(),
         ];

--- a/src/Export/Data/Entity/ProductEntityInterface.php
+++ b/src/Export/Data/Entity/ProductEntityInterface.php
@@ -7,4 +7,5 @@ namespace Omikron\FactFinder\Shopware6\Export\Data\Entity;
 interface ProductEntityInterface
 {
     public function getProductNumber(): string;
+    public function getProductName(): string;
 }

--- a/src/Export/Data/Entity/VariantEntity.php
+++ b/src/Export/Data/Entity/VariantEntity.php
@@ -42,9 +42,14 @@ class VariantEntity implements ExportEntityInterface, ProductEntityInterface
         return $this->product->getProductNumber();
     }
 
+    public function getProductName(): string
+    {
+        return $this->product->getTranslation('name') ? (string) $this->product->getTranslation('name') : $this->parentData['Name'];
+    }
+
     public function toArray(): array
     {
         $opts = '|' . implode('|', map($this->propertyFormatter, $this->product->getOptions()->getElements())) . '|';
-        return array_reduce($this->variantFields, fn (array $fields, FieldInterface $field): array => [$field->getName() => $field->getValue($this->product)] + $fields, ['ProductNumber' => $this->product->getProductNumber(), 'FilterAttributes' => $opts] + $this->parentData);
+        return array_reduce($this->variantFields, fn (array $fields, FieldInterface $field): array => [$field->getName() => $field->getValue($this->product)] + $fields, ['ProductNumber' => $this->product->getProductNumber(), 'Name' => $this->getProductName(), 'FilterAttributes' => $opts] + $this->parentData);
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -46,6 +46,7 @@
         </parameter>
         <parameter key="factfinder.export.associations" type="collection">
             <parameter key="variant_cover">children.media</parameter>
+            <parameter key="variant_translations">children.translations</parameter>
         </parameter>
         <parameter key="factfinder.navigation.category_path_field_name" type="string">CategoryPath</parameter>
         <parameter key="factfinder.category_page.add_params" type="collection">


### PR DESCRIPTION
Example how to export variants names. 
Due to the performance impact on the export process, such a change must be made directly on the website of the customer who wants to export variant names.