### PR TITLE
FFWEB-3227: Add the ability to set a name for the CategoryPath field

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -19,31 +19,31 @@ return $config
     ->setHideProgress(true)
     ->setUsingCache(false)
     ->setRules([
-                   '@PSR2'                        => true,
-                   '@PSR12'                       => true,
-                   '@PHP74Migration:risky'        => true,
-                   '@Symfony'                     => true,
-                   'array_syntax'                 => ['syntax' => 'short'],
-                   'binary_operator_spaces'       => [
-                       'operators' => [
-                           '='  => 'align',
-                           '=>' => 'align',
-                       ],
-                   ],
-                   'blank_line_after_opening_tag'                     => true,
-                   'line_ending'                                      => true,
-                   'class_attributes_separation'                      => false,
-                   'blank_line_before_statement'                      => ['statements' => ['break', 'continue', 'declare', 'throw', 'try']],
-                   'concat_space'                                     => ['spacing' => 'one'],
-                   'declare_strict_types'                             => true,
-                   'increment_style'                                  => ['style' => 'post'],
-                   'no_superfluous_phpdoc_tags'                       => false,
-                   'no_useless_else'                                  => true,
-                   'no_useless_return'                                => true,
-                   'ordered_class_elements'                           => true,
-                   'ordered_imports'                                  => ['imports_order' => ['class', 'function', 'const']],
-                   'strict_comparison'                                => true,
-                   'yoda_style'                                       => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
-                   'nullable_type_declaration_for_default_null_value' => false,
-               ])
+        '@PSR2'                        => true,
+        '@PSR12'                       => true,
+        '@PHP74Migration:risky'        => true,
+        '@Symfony'                     => true,
+        'array_syntax'                 => ['syntax' => 'short'],
+        'binary_operator_spaces'       => [
+            'operators' => [
+                '='  => 'align',
+                '=>' => 'align',
+            ],
+        ],
+        'blank_line_after_opening_tag'                     => true,
+        'line_ending'                                      => true,
+        'class_attributes_separation'                      => false,
+        'blank_line_before_statement'                      => ['statements' => ['break', 'continue', 'declare', 'throw', 'try']],
+        'concat_space'                                     => ['spacing' => 'one'],
+        'declare_strict_types'                             => true,
+        'increment_style'                                  => ['style' => 'post'],
+        'no_superfluous_phpdoc_tags'                       => false,
+        'no_useless_else'                                  => true,
+        'no_useless_return'                                => true,
+        'ordered_class_elements'                           => true,
+        'ordered_imports'                                  => ['imports_order' => ['class', 'function', 'const']],
+        'strict_comparison'                                => true,
+        'yoda_style'                                       => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+        'nullable_type_declaration_for_default_null_value' => false,
+    ])
     ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Improve
+- Add the ability to set a name for the CategoryPath field (category page)
+
 ## [v6.0.0] - 2024.07.12
 ### BREAKING
 - IMPORTANT! Drop Shopware 6.5 compatibility

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ modifications in order to fit their needs. For more advanced features please che
       - [Campaigns Element](#campaigns-element)
     - [Blocks and Elements Templates](#blocks-and-elements-templates)
     - [Assigning Layout to Category](#assigning-layout-to-category)
+    - [Set correct name for CategoryPath field](#set-correct-name-for-categorypath-field)
 - [Exporting Feeds](#exporting-feeds)
     - [CLI](#cli)
     - [Selecting Categories for CMS Export](#selecting-categories-for-cms-export)
@@ -276,6 +277,15 @@ Once the page layout is done, you need to assign layout to selected categories.
 We strongly recommend not creating many layouts as currently there's still only few possibilities offered anyway.
 Future development will bring more blocks and elements will be provided here.
 
+### Set correct name for CategoryPath field
+
+By default, SDK uses a field named CategoryPath (default field name for FactFinder instance). 
+If in your FactFinder instance configuration you have a different field name for Category field then you must set this name in the `services.xml` file as shown below:
+
+    //src/Resources/config/services.xml:34
+    <parameter key="factfinder.navigation.category_path_field_name" type="string">CategoryPath</parameter>
+
+
 ## Exporting Feeds
 
 FACT-Finder allows to export different types of feeds, like a **products**, **cms** and **brands** (or manufacturers)
@@ -503,6 +513,9 @@ where `$association` would be a `children.cover` in that example.
 
 **Note:**
 Please note that adding more and more associations will have an impact on overall export performance.
+
+**Note:**
+If you need to export variant names in data feed you could use [this sample code as an example](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/pull/258):
 
 ### Creating Custom Entity Export
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -47,7 +47,6 @@
         <parameter key="factfinder.export.associations" type="collection">
             <parameter key="variant_cover">children.media</parameter>
         </parameter>
-        <parameter key="factfinder.navigation.category_path_field_name" type="string">CategoryPath</parameter>
         <parameter key="factfinder.category_page.add_params" type="collection">
         </parameter>
         <parameter key="factfinder.configuration.add_params" type="collection">

--- a/src/Resources/views/storefront/block/cms-block-listing.html.twig
+++ b/src/Resources/views/storefront/block/cms-block-listing.html.twig
@@ -7,7 +7,10 @@
     document.addEventListener(`ffCoreReady`, ({ factfinder }) => {
       factfinder.config.setAppConfig({
         categoryPage: [
-          factfinder.utils.filterBuilders.categoryFilter(`CategoryPath`, {{ (page.extensions.factfinder.communication.categoryPage|split(',')|json_encode())|raw }})
+          factfinder.utils.filterBuilders.categoryFilter(
+            '{{ page.extensions.factfinder.categoryPathFieldName|replace({'ROOT': ''}) }}',
+            {{ (page.extensions.factfinder.communication.categoryPage|split(',')|json_encode())|raw }}
+          )
     ],
     });
 


### PR DESCRIPTION
- Solves issue: FFWEB-3227
- Description: Add the ability to set a name for the CategoryPath field (category page)
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.3
