### PR TITLE
FFWEB-3231: Reset useId in WebComponents after user logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Improve
 - Add the ability to set a name for the CategoryPath field (category page)
+- Reset useId in WebComponents after user logout
 
 ### Change
 - Upgrade Web Components version to v5.0.0-pre.4

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -121,9 +121,7 @@
       } else {
         if (ffCookies['ff_has_just_logged_out']) {
           clearCookie('ff_has_just_logged_out');
-          //Need to fix in webcomponents
-          //Now reset userId is impossible
-          // factfinder.config.setFFParams({userId: 'undefined'});
+          factfinder.config.setFFParams({userId: undefined});
         }
       }
 


### PR DESCRIPTION
- Solves issue: FFWEB-3231
- Description: Reset useId in WebComponents after user logout
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2
