### PR TITLE
FFWEB-3253: Remove multiple redirect to search result page 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Don't redirect to search result page if search is executed already on result page
+
 ## [v6.0.1] - 2024.11.21
 ### Improve
 - Add the ability to set a name for the CategoryPath field (category page)

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -36,12 +36,14 @@
             return;
           }
 
-          if (searchOptions?.requestOptions?.origin?.tagName === `FF-SEARCHBOX`) {
-            window.location.href =  `/factfinder/result?query=${searchParams.query}`;
+          {% if app.request.pathInfo !== "/factfinder/result" %}
+            if (searchOptions?.requestOptions?.origin?.tagName === `FF-SEARCHBOX`) {
+              window.location.href =  `/factfinder/result?query=${searchParams.query}`;
 
-            // Cancel the pipeline to avoid sending a search request to FactFinder before the redirect is complete.
-            return false;
-          }
+              // Cancel the pipeline to avoid sending a search request to FactFinder before the redirect is complete.
+              return false;
+            }
+          {% endif %}
         });
 
         {% if page.extensions.factfinder.searchImmediate and not page.extensions.factfinder.ssr %}


### PR DESCRIPTION
- Solves issue: FFWEB-3253
- Description: Don't redirect to search result page if search in executed already on result page
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2

