### PR TITLE
FFWEB-3296: Fix problem with comma in category name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Set correct CategoryPath field name for searchParamsFromUrl
 - Fix Filter off-canvas issue
 - Fix Proxy issue on PDP and for tracking requests
+- Fix problem with comma ',' in category name
 
 ### Change
 - Update FactFinder logo icon

--- a/spec/Subscriber/CategoryPageSubscriberSpec.php
+++ b/spec/Subscriber/CategoryPageSubscriberSpec.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CategoryPageSubscriberSpec extends ObjectBehavior
 {
-    private string $filterCategoryPath = 'Books + Sports,Home / Garden 100%';
+    private string $filterCategoryPath = 'Books + Sports||Home / Garden 100%';
 
     public function let(
         AbstractCategoryRoute $cmsPageRoute,

--- a/src/Resources/views/storefront/block/cms-block-listing.html.twig
+++ b/src/Resources/views/storefront/block/cms-block-listing.html.twig
@@ -9,7 +9,7 @@
         categoryPage: [
           factfinder.utils.filterBuilders.categoryFilter(
             '{{ page.extensions.factfinder.categoryPathFieldName|replace({'ROOT': ''}) }}',
-            {{ (page.extensions.factfinder.communication.categoryPage|split(',')|json_encode())|raw }}
+            {{ (page.extensions.factfinder.communication.categoryPage|split('||')|json_encode())|raw }}
           )
     ],
     });

--- a/src/Utilites/Ssr/Field/CategoryPath.php
+++ b/src/Utilites/Ssr/Field/CategoryPath.php
@@ -19,7 +19,7 @@ class CategoryPath
     {
         $categories   = array_slice($categoryEntity->getBreadcrumb(), 1);
 
-        return implode(',', $categories);
+        return implode('||', $categories);
     }
 
     public function getSsrValue(CategoryEntity $categoryEntity): string


### PR DESCRIPTION
- Solves issue: FFWEB-3296
- Description: Fix problem with comma in category name
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.3

