### PR TITLE
FFWEB-3297: Introduce Handlebars.js template engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 ## Unreleased
+### Change
+- Update FactFinder logo icon
+- Introduce Handlebars.js template engine instead of Mustache.js in SSR
+
 ### Fix
 - Set correct CategoryPath field name for searchParamsFromUrl
 - Fix Filter off-canvas issue
 - Fix Proxy issue on PDP and for tracking requests
 - Fix problem with comma ',' in category name
-
-### Change
-- Update FactFinder logo icon
 
 ## [v6.0.2] - 2024.12.10
 ### Fix

--- a/README.md
+++ b/README.md
@@ -396,6 +396,9 @@ Plugin templates could be found in `Resources/views/storefront/`. Just as with t
 extending default Storefront wherever it is possible. You can use these templates if you are extending it
 using `sw_extends` which offers a support for a multi inheritance.
 
+FactFinder Web Components uses handlebars as the engine to resolve its HTML templates. Please refer to the official documentation for available features and their usage:
+https://handlebarsjs.com/
+
 ### Tracking
 
 Plugin offers a following way of tracking customer actions

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "shopware/core": "~6.6.0",
     "shopware/storefront": "~6.6.0",
     "php": "~8.2.0||~8.3.0",
-    "mustache/mustache": "^2.14",
+    "salesforce/handlebars-php": "3.*",
     "league/flysystem-sftp-v3": "^3.0",
     "league/flysystem-ftp": "^3.0"
   },
@@ -46,7 +46,6 @@
     "allow-plugins": {
       "symfony/*": true,
       "omikron/*": true,
-      "mustache/mustache": true
     }
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   "config": {
     "allow-plugins": {
       "symfony/*": true,
-      "omikron/*": true,
+      "omikron/*": true
     }
   },
   "extra": {

--- a/spec/Storefront/Controller/ResultControllerSpec.php
+++ b/spec/Storefront/Controller/ResultControllerSpec.php
@@ -81,7 +81,7 @@ class ResultControllerSpec extends ObjectBehavior
     public function it_should_return_original_response_content_when_ssr_is_not_active(
         SearchAdapter $searchAdapter,
         Page $page,
-        Engine $mustache
+        Engine $handlebars
     ): void {
         $content = 'original content';
         $this->pageLoader->load($this->request, $this->salesChannelContext)->willReturn($page);
@@ -93,7 +93,7 @@ class ResultControllerSpec extends ObjectBehavior
             $this->request,
             $this->salesChannelContext,
             $searchAdapter,
-            $mustache
+            $handlebars
         );
 
         $response->shouldBeAnInstanceOf(Response::class);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -182,10 +182,12 @@
             <argument type="service" id="product.repository"/>
         </service>
 
-        <service id="Mustache_Engine" alias="factfinder.mustache_engine" />
         <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\StringLoader" />
         <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Filter" />
-        <service id="Mustache_Loader_StringLoader" alias="factfinder.mustache_loader_string_loader" />
+
+        <service id="Handlebars\Handlebars" alias="factfinder.handlebars_engine" />
+        <service id="Handlebars\Loader\StringLoader" alias="factfinder.handlebars_loader_string_loader" />
+
         <service id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Loader">
             <argument type="service" id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\StringLoader"/>
             <argument type="service" id="Omikron\FactFinder\Shopware6\Utilites\Ssr\Template\Filter"/>

--- a/src/Resources/public/ff-web-components/bundle.js.LICENSE
+++ b/src/Resources/public/ff-web-components/bundle.js.LICENSE
@@ -27,6 +27,6 @@
  */
 
 /*!
- * mustache.js - Logic-less {{mustache}} templates with JavaScript
- * http://github.com/janl/mustache.js
+ * handlebars.js - Logic-less {{handlebars}} templates with JavaScript
+ * https://handlebarsjs.com/
  */

--- a/src/Resources/views/storefront/components/factfinder/no-results.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/no-results.html.twig
@@ -1,10 +1,10 @@
 {% block component_factfinder_record_list_no_results %}
   <ff-template class="cms-listing-col col-12" scope="SearchAndNavigation" unresolved>
-    {{ '{{^hits}}' }}
-    {% sw_include '@Parent/storefront/utilities/alert.html.twig' with {
-      type: 'info',
-      content: 'listing.emptyResultMessage'|trans|sw_sanitize
-    } %}
-    {{ '{{/hits}}' }}
+    {{ '{{#unless hits}}' }}
+      {% sw_include '@Parent/storefront/utilities/alert.html.twig' with {
+        type: 'info',
+        content: 'listing.emptyResultMessage'|trans|sw_sanitize
+      } %}
+    {{ '{{/unless}}' }}
   </ff-template>
 {% endblock %}

--- a/src/Storefront/Controller/ResultController.php
+++ b/src/Storefront/Controller/ResultController.php
@@ -31,7 +31,7 @@ class ResultController extends StorefrontController
         Request $request,
         SalesChannelContext $context,
         SearchAdapter $searchAdapter,
-        Engine $mustache,
+        Engine $handlebars,
     ): Response {
         $page     = $this->pageLoader->load($request, $context);
         $response = $this->renderStorefront('@Parent/storefront/page/factfinder/result.html.twig', ['page' => $page]);
@@ -42,7 +42,7 @@ class ResultController extends StorefrontController
 
         $recordList = new RecordList(
             $request,
-            $mustache,
+            $handlebars,
             $searchAdapter,
             $context->getSalesChannelId(),
             $response->getContent(),

--- a/src/Subscriber/CategoryPageResponseSubscriber.php
+++ b/src/Subscriber/CategoryPageResponseSubscriber.php
@@ -29,7 +29,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
     private EntityRepository $categoryRepository;
     private Communication $config;
     private SearchAdapter $searchAdapter;
-    private Engine $mustache;
+    private Engine $handlebars;
     private CategoryPath $categoryPath;
 
     public function __construct(
@@ -37,14 +37,14 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
         EntityRepository $categoryRepository,
         Communication $config,
         SearchAdapter $searchAdapter,
-        Engine $mustache,
+        Engine $handlebars,
         CategoryPath $categoryPath,
     ) {
         $this->httpCacheEnabled       = $httpCacheEnabled;
         $this->categoryRepository     = $categoryRepository;
         $this->config                 = $config;
         $this->searchAdapter          = $searchAdapter;
-        $this->mustache               = $mustache;
+        $this->handlebars             = $handlebars;
         $this->categoryPath           = $categoryPath;
     }
 
@@ -76,7 +76,7 @@ class CategoryPageResponseSubscriber implements EventSubscriberInterface
 
         $recordList = new RecordList(
             $request,
-            $this->mustache,
+            $this->handlebars,
             $this->searchAdapter,
             $request->attributes->get('sw-sales-channel-id'),
             $response->getContent(),

--- a/src/Utilites/Ssr/Template/Engine.php
+++ b/src/Utilites/Ssr/Template/Engine.php
@@ -4,26 +4,19 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
 
-use Mustache_Engine as Mustache;
+use Handlebars\Handlebars;
 
 class Engine
 {
-    private Mustache $engine;
+    private Handlebars $engine;
 
     public function __construct(Loader $loader)
     {
-        $this->engine = new Mustache(
-            [
-                'loader'           => $loader,
-                'strict_callables' => true,
-            ]
-        );
+        $this->engine = new Handlebars(['loader' => $loader]);
     }
 
-    public function render(
-        string $templateFile,
-        array $context = [],
-    ): string {
+    public function render(string $templateFile, array $context = []): string
+    {
         return $this->engine->loadTemplate($templateFile)->render($context);
     }
 }

--- a/src/Utilites/Ssr/Template/Loader.php
+++ b/src/Utilites/Ssr/Template/Loader.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
 
+use Handlebars\Loader as HandlebarsLoader;
 use Omikron\FactFinder\Shopware6\Export\Filter\FilterInterface;
 
-class Loader implements \Mustache_Loader
+class Loader implements HandlebarsLoader
 {
-    private \Mustache_Loader $loader;
+    private HandlebarsLoader $loader;
     private FilterInterface $filter;
 
     public function __construct(
-        \Mustache_Loader $loader,
+        HandlebarsLoader $loader,
         FilterInterface $filter,
     ) {
         $this->loader = $loader;
@@ -25,6 +26,7 @@ class Loader implements \Mustache_Loader
     public function load($name)
     {
         $template = $this->loader->load($name);
-        return $template instanceof \Mustache_Source ? $template : $this->filter->filterValue($template);
+
+        return $this->filter->filterValue((string) $template);
     }
 }

--- a/src/Utilites/Ssr/Template/RecordList.php
+++ b/src/Utilites/Ssr/Template/RecordList.php
@@ -14,7 +14,7 @@ class RecordList
     private const SSR_RECORD_PATTERN = '#<ssr-record-template>.*?</ssr-record-template>#s';
 
     private Request $request;
-    private Engine $mustache;
+    private Engine $handlebars;
     private SearchAdapter $searchAdapter;
     private string $salesChannelId;
     private string $content;
@@ -22,13 +22,13 @@ class RecordList
 
     public function __construct(
         Request $request,
-        Engine $mustache,
+        Engine $handlebars,
         SearchAdapter $searchAdapter,
         string $salesChannelId,
         string $content,
     ) {
         $this->request        = $request;
-        $this->mustache       = $mustache;
+        $this->handlebars     = $handlebars;
         $this->searchAdapter  = $searchAdapter;
         $this->salesChannelId = $salesChannelId;
         $this->content        = $content;
@@ -78,7 +78,7 @@ class RecordList
             fn (string $carry, array $record) => sprintf(
                 '%s%s',
                 $carry,
-                $this->mustache->render($this->template, $record)
+                $this->handlebars->render($this->template, $record)
             ),
             ''
         );

--- a/src/Utilites/Ssr/Template/StringLoader.php
+++ b/src/Utilites/Ssr/Template/StringLoader.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Shopware6\Utilites\Ssr\Template;
 
-class StringLoader extends \Mustache_Loader_StringLoader
+use Handlebars\Loader\StringLoader as HandlebarsStringLoader;
+
+class StringLoader extends HandlebarsStringLoader
 {
 }


### PR DESCRIPTION
- Solves issue: FFWEB-3297
- Description: Introduce Handlebars.js template engine instead of Mustache.js in SSR
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2
