### PR TITLE
FFWEB-3301: Remove CategoryPath filter in URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Remove CategoryPath filter in URL and ASN on category page
+
 ## [v6.1.0] - 2025.01.28
 ### Change
 - Update FactFinder logo icon

--- a/src/Resources/views/storefront/block/cms-block-listing.html.twig
+++ b/src/Resources/views/storefront/block/cms-block-listing.html.twig
@@ -4,15 +4,19 @@
 
 {#  <!-- Category page -->#}
   <script>
-    document.addEventListener(`ffCoreReady`, ({ factfinder }) => {
+    document.addEventListener(`ffCoreReady`, ({ factfinder, initialSearch }) => {
       factfinder.config.setAppConfig({
         categoryPage: [
           factfinder.utils.filterBuilders.categoryFilter(
-            '{{ page.extensions.factfinder.categoryPathFieldName|replace({'ROOT': ''}) }}',
+            '{{ page.extensions.factfinder.categoryPathFieldName }}',
             {{ (page.extensions.factfinder.communication.categoryPage|split('||')|json_encode())|raw }}
           )
-    ],
-    });
+        ],
+      });
+
+      factfinder.routing.setUrlParamOptionsListener(() => ({
+        blockFilters: [`{{ page.extensions.factfinder.categoryPathFieldName }}`],
+      }));
 
       {% if page.extensions.factfinder.ssr == 'ssr' %}
         const searchResult = {FF_SEARCH_RESULT};
@@ -21,7 +25,11 @@
           factfinder.response.dispatch.ssrNavigation(searchResult);
         }
       {% else %}
-        factfinder.request.navigation({'filters': factfinder.config.get().appConfig.categoryPage}, { requestOptions: { origin: `searchImmediately` } });
+
+     const initOptions = factfinder.config.get();
+        initialSearch({
+          filters: initOptions.appConfig.categoryPage,
+        });
       {% endif %}
     });
   </script>
@@ -79,5 +87,3 @@
     </div>
   </div>
 {% endblock %}
-
-

--- a/src/Resources/views/storefront/block/cms-block-listing.html.twig
+++ b/src/Resources/views/storefront/block/cms-block-listing.html.twig
@@ -25,8 +25,7 @@
           factfinder.response.dispatch.ssrNavigation(searchResult);
         }
       {% else %}
-
-     const initOptions = factfinder.config.get();
+        const initOptions = factfinder.config.get();
         initialSearch({
           filters: initOptions.appConfig.categoryPage,
         });

--- a/src/Subscriber/CategoryPageSubscriber.php
+++ b/src/Subscriber/CategoryPageSubscriber.php
@@ -77,7 +77,7 @@ class CategoryPageSubscriber implements EventSubscriberInterface
                 'trackingSettings'        => $this->extensionConfig->getTrackingSettings(),
                 'redirectMapping'         => (string) $this->extensionConfig->getRedirectMapping(),
                 'searchImmediate'         => false,
-                'categoryPathFieldName'   => "{$this->fieldName}ROOT",
+                'categoryPathFieldName'   => (string) $this->fieldName,
                 'communicationAttributes' => !empty($communicationConfig) ? $this->getCommunicationAttributes($communicationConfig) : $communication,
             ]
         );


### PR DESCRIPTION
- Solves issue: FFWEB-3301
- Description: Remove CategoryPath filter in URL and ASN on category page
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2

