### PR TITLE
FFWEB-3343: Fix GitHub actions cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Load Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.deps }}-composer


### PR DESCRIPTION
- Solves issue: FFWEB-3343
- Description: Fix GitHub actions cache
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**
