### PR TITLE
FFWEB-3355: Fix filter cloud issue on category pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Fix filter cloud issue on category pages
+
 ## [v6.3.1] - 2025.03.04
 ### Change
 - Upgrade Web Components version to v5.1.1

--- a/src/Resources/views/storefront/block/cms-block-listing.html.twig
+++ b/src/Resources/views/storefront/block/cms-block-listing.html.twig
@@ -26,9 +26,13 @@
         }
       {% else %}
         const initOptions = factfinder.config.get();
-        initialSearch({
-          filters: initOptions.appConfig.categoryPage,
-        });
+        const searchParams = factfinder.utils.env.searchParamsFromUrl(
+          { categoryFieldName: `{{ page.extensions.factfinder.categoryPathFieldName }}` }
+        );
+
+        searchParams.filters = searchParams.filters ?? [];
+        searchParams.filters.push(initOptions.appConfig.categoryPage[0]);
+        initialSearch(searchParams);
       {% endif %}
     });
   </script>


### PR DESCRIPTION
- Solves issue: FFWEB-3355
- Description: Fix filter cloud issue on category pages
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2

