### PR TITLE
FFWEB-3365: Add price attribute for ff-checkout-tracking-item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fix
 - Fix filter cloud issue on category pages
 - Fix ff-asn-remove-all-filters issue on mobile view
+- Add price attribute for ff-checkout-tracking-item
 
 ### Remove
 - CMS blocks - remove `infinity scrolling` from `ff-record-list` (not supported by Web Components v5)

--- a/src/Resources/views/storefront/page/checkout/finish/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/finish/index.html.twig
@@ -6,6 +6,7 @@
       <ff-checkout-tracking-item
         product-number="{{ lineItem.payload.productNumber }}"
         count="{{ lineItem.quantity }}"
+        price="{{ lineItem.unitPrice }}"
         channel="{{ page.extensions.factfinder.communication.channel }}">
       </ff-checkout-tracking-item>
     {% endfor %}


### PR DESCRIPTION
- Solves issue: FFWEB-3365
- Description: Add price attribute for ff-checkout-tracking-item
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.3

