### PR TITLE
FFWEB-3370: Add facet name to filter cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Change
+- Add facet name to filter cloud
+
 ## [v6.3.2] - 2025.04.02
 ### Fix
 - Fix filter cloud issue on category pages

--- a/src/Resources/views/storefront/components/factfinder/asn.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/asn.html.twig
@@ -65,7 +65,7 @@
           {% if filterCloudOrder %} order="{{ filterCloudOrder }}" {% endif %}
           unresolved>
           <span data-template="filter" class="filter-active">
-            {{ '{{$facetElement}}' }}
+            {{ '{{facet.name}}' }}: {{ '{{$facetElement}}' }}
             <button class="filter-active-remove">
               &times;
             </button>


### PR DESCRIPTION
- Solves issue: FFWEB-3370
- Description:  Add facet name to filter cloud
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2

