### PR TITLE
prevent blocking cookie consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [v6.3.3] - 2025.04.09
+- prevent block by Cookie Consent (Cookiebot by Usercentrics)
+
 ## [v6.3.2] - 2025.04.02
 ### Fix
 - Fix filter cloud issue on category pages

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -4,7 +4,7 @@
   {% block base_body_inner_factfinder_communication %}
 
     <!--Main FF Web-components Initialisation -->
-    <script>
+    <script data-cookieconsent="ignore">
       document.addEventListener(`ffCoreReady`, ({ factfinder, init, initialSearch }) => {
 
         init({


### PR DESCRIPTION
- **Solves issue**:
  - The cookie consent „Cookiebot by Usercentrics“ block this scripts and visitors get the error `'init' was not called during 'ffCoreReady' event`.
  - The shop will only be fully usable if the user accepts everything in the cookie consent and reloads the page

- **Description**:<br>This change includes no breaking changes, but FactFinder works with the cookie consent
- **Tested with Shopware6 editions/versions**:<br>6.6.6.1
- **Tested with PHP versions**:<br>8.2.26

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/shopware6-plugin/blob/HEAD/.github/CONTRIBUTING.md)).**  
I see no master branch.