### PR TITLE
FFWEB-3369:  Add tracking for product card add to cart action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## Unreleased
+### Add
+- Add tracking for product card add to cart action
+
 ### Change
 - Add facet name to filter cloud
 - Improve filter display for `ff-breadcrumb-trail-item`

--- a/src/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Resources/views/storefront/component/product/card/action.html.twig
@@ -1,0 +1,6 @@
+{% sw_extends '@Parent/storefront/component/product/card/action.html.twig' %}
+
+{% block page_product_detail_product_buy_meta %}
+  {{ parent() }}
+  <input type="hidden" name="product-number" value="{{ product.productNumber }}">
+{% endblock %}


### PR DESCRIPTION
- Solves issue: FFWEB-3369
- Description: Add tracking for product card add to cart action
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2
