### PR TITLE
FFWEB-3399: Support tab navigation for slider and ff-suggest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 ### Fix
 - Support tab navigation for `ff-asn` (EAA)
+- Support tab navigation for `ff-asn-group-slider` and `ff-suggest` (EAA)
+
 ## [v6.4.0] - 2025.06.20
 ### Add
 - Add tracking for product card add to cart action

--- a/src/Resources/app/storefront/src/scss/_asn.scss
+++ b/src/Resources/app/storefront/src/scss/_asn.scss
@@ -51,6 +51,10 @@ ff-asn {
   }
 
   &-group-slider {
+    .ffw-wrapper {
+      display: none;
+    }
+
     .ffw-wrapper[opened] {
       display: flex;
       flex-direction: column;

--- a/src/Resources/views/storefront/components/factfinder/asn.html.twig
+++ b/src/Resources/views/storefront/components/factfinder/asn.html.twig
@@ -56,10 +56,10 @@
       {% endblock %}
 
       <ff-asn-group-slider class="filter-panel-item dropdown" disable-auto-expand="true">
-        <div slot="groupCaption" class="filter-panel-item-toggle btn">
+        <button slot="groupCaption" class="filter-panel-item-toggle btn">
           {{ '{{group.name}}' }}
           {% sw_icon 'arrow-medium-down' style { 'pack': 'solid', 'size': 'xs', 'class': 'filter-panel-item-toggle' } %}
-        </div>
+        </button>
       </ff-asn-group-slider>
     </ff-asn>
   {% endblock %}

--- a/src/Resources/views/storefront/layout/factfinder/suggest.html.twig
+++ b/src/Resources/views/storefront/layout/factfinder/suggest.html.twig
@@ -13,21 +13,21 @@
           <div data-container="searchTerm" class="col">
             <h3 class="h5 container-caption">{{ 'ff.suggest.SearchTerms'|trans|striptags }}</h3>
             <ff-suggest-item type="searchTerm">
-              <span class="ff-search-term">{{ '{{{name}}}' }}</span>
+              <a href="#" class="ff-search-term">{{ '{{{name}}}' }}</a>
             </ff-suggest-item>
           </div>
 
           <div data-container="category" class="col">
             <h3 class="h5 container-caption">{{ 'ff.suggest.Categories'|trans|striptags }}</h3>
             <ff-suggest-item type="category">
-              <span class="ff-category">{{ '{{{name}}}' }}</span>
+              <a href="#" class="ff-category">{{ '{{{name}}}' }}</a>
             </ff-suggest-item>
           </div>
 
           <div data-container="brand" class="col">
             <h3 class="h5 container-caption">{{ 'ff.suggest.Brands'|trans|striptags }}</h3>
             <ff-suggest-item type="brand">
-              <span class="ff-brand">{{ '{{{name}}}' }}</span>
+              <a href="#" class="ff-brand">{{ '{{{name}}}' }}</a>
             </ff-suggest-item>
           </div>
         </section>
@@ -44,7 +44,7 @@
                     <div class="col-auto search-suggest-product-image-container">
                       <img class="search-suggest-product-image" data-image="{{ '{{image}}' }}" alt="photo"/>
                     </div>
-                    <div class="col search-suggest-product-name">{{ '{{{name}}}' }}</div>
+                    <a href="#" class="col search-suggest-product-name">{{ '{{{name}}}' }}</a>
                     <div class="col-auto search-suggest-product-price">{{ '{{attributes.Price}}' }}</div>
                   </div>
                 </div>


### PR DESCRIPTION
- Solves issue: FFWEB-3399
- Description: Support tab navigation for slider and ff-suggest
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.3

