### PR TITLE
FFWEB-3402: Fix price slider bar position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fix
 - Support tab navigation for `ff-asn` (EAA)
 - Support tab navigation for `ff-asn-group-slider` and `ff-suggest` (EAA)
+- Fix price slider bar position
 
 ### Change
 - Upgrade Web Components version to v5.1.5 (EAA for `ff-record-list`)

--- a/src/Resources/app/storefront/src/scss/_asn.scss
+++ b/src/Resources/app/storefront/src/scss/_asn.scss
@@ -52,13 +52,14 @@ ff-asn {
 
   &-group-slider {
     .ffw-wrapper {
-      display: none;
+      visibility: hidden
     }
 
     .ffw-wrapper[opened] {
       display: flex;
       flex-direction: column;
       text-align: center;
+      visibility: visible;
     }
   }
 


### PR DESCRIPTION
- Solves issue: FFWEB-3402
- Description: Fix price slider bar position
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.3

