### PR TITLE
FFWEB-3261: Change default behavior for add to cart btn tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,12 @@ by default export outputs data in the STDOUT. It could be easily redirected usin
 
     php [SHOPWARE_ROOT]/bin/console factfinder:data:export -n > export.csv
 
+Console command can be executed with a variable from .env file e.g. `APP_URL=http://saleschannel-domain.com`.
+This is especially useful if you have several SalesChannels with different domains, and you want the ImageUrl of products to be set to the domain from a specific SalesChannel.
+
+    APP_URL=http://saleschannel-domain.com php [SHOPWARE_ROOT]/bin/console factfinder:data:export
+
+
 #### Selecting Categories for CMS Export
 With CMS Export we introduced custom field for CategoryEntity by which we filter the Categories going to be exported.
 You can find it on Category edit page. 

--- a/spec/Subscriber/CategoryPageSubscriberSpec.php
+++ b/spec/Subscriber/CategoryPageSubscriberSpec.php
@@ -162,7 +162,7 @@ class CategoryPageSubscriberSpec extends ObjectBehavior
         $extensionConfig->getTrackingSettings()->willReturn(
             [
                 'addToCart' => [
-                    'count' => 'count_as_one',
+                    'count' => 'count_selected_amount',
                 ],
             ]
         );

--- a/spec/Subscriber/ConfigurationSubscriberSpec.php
+++ b/spec/Subscriber/ConfigurationSubscriberSpec.php
@@ -38,7 +38,7 @@ class ConfigurationSubscriberSpec extends ObjectBehavior
         $extensionConfig->getTrackingSettings()->willReturn(
             [
                 'addToCart' => [
-                    'count' => 'count_as_one',
+                    'count' => 'count_selected_amount',
                 ],
             ]
         );

--- a/src/Config/ExtensionConfig.php
+++ b/src/Config/ExtensionConfig.php
@@ -25,7 +25,7 @@ class ExtensionConfig extends BaseConfig
     {
         return [
             'addToCart' => [
-                'count' => (string) $this->config('trackingAddToCartCount') ?? 'count_as_one',
+                'count' => (string) $this->config('trackingAddToCartCount') ?? 'count_selected_amount',
             ],
         ];
     }

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -76,7 +76,7 @@
                     <name lang="de-DE">Verfolgen Sie einen einzelnen Klick mit dem ausgewählten Betrag</name>
                 </option>
             </options>
-            <defaultValue>count_as_one</defaultValue>
+            <defaultValue>count_selected_amount</defaultValue>
             <label>Scenario how to count single click on "Add to cart" button</label>
             <label lang="de-DE">Szenario zum Zählen mit einem Klick auf die Schaltfläche „In den Warenkorb“</label>
             <required>true</required>


### PR DESCRIPTION
- Solves issue: FFWEB-3261
- Description: Change default behavior for add to cart btn tracking. Now default is set to count_selected_amount
- Tested with Shopware6 editions/versions: 6.6
- Tested with PHP versions: 8.2
