### PR TITLE
FFWEB-3410: Update documentation and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 # Changelog
+## Unreleased
+### BREAKING
+- IMPORTANT! Drop Shopware 6.6 compatibility
+- IMPORTANT! Drop Webpack compatibility
+- Add support for Shopware 6.7
+- Add support for PHP 8.4
+- Add support for Vite
+- Upgrade libraries as required Shopware v6.7
+- Upgrade Symfony to version 7.1
+
+### Add
+- Support tab navigation for `ff-asn` and `ff-suggest` (EAA)
+
+### Change
+- Change default behavior for add to cart btn tracking
+- Upgrade Web Components version to v5.1.5
+
+### Fix
+- Fix ImageUrl for product export feature
+
 ## [v6.4.0] - 2025.06.20
 ### Add
 - Add tracking for product card add to cart action
-- Add improvements for European Accessibility Act
+- Add improvements for European Accessibility Act (EAA)
 
 ### Change
 - Add facet name to filter cloud

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ modifications in order to fit their needs. For more advanced features please che
 
 ## System Requirements
 
-- Shopware 6.6
-- PHP version: 8.2 or 8.3
-
-For Shopware 6.4 please use SDK version 4.x:
-https://github.com/FACT-Finder-Web-Components/shopware6-plugin/tree/release/4.x
+- Shopware 6.7
+- PHP version: 8.2, 8.3 or 8.4
 
 For Shopware 6.5 please use SDK version 5.x:
 https://github.com/FACT-Finder-Web-Components/shopware6-plugin/tree/release/5.x
+
+For Shopware 6.6 please use SDK version 6.x:
+https://github.com/FACT-Finder-Web-Components/shopware6-plugin/tree/release/6.x
 
 ## FACT-Finder® Supported Sections
 


### PR DESCRIPTION
- Solves issue: FFWEB-3410
- Description: Update documentation and changelog before release
- Tested with Shopware6 editions/versions: 6.7
- Tested with PHP versions: 8.3

